### PR TITLE
Add PyPI publish workflow and maintainers metadata

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,62 @@
+name: "Build and publish package"
+
+on:
+  release:
+    types: [published]
+
+env:
+  UV_FROZEN: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # required for hatch-vcs to read git tags
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libldap2-dev libsasl2-dev
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Build package
+        run: uv build --out-dir dist/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docling-pipelines
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+          packages-dir: dist/
+          skip-existing: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The docpipe project is a modular, operator-based data processing framework desig
 
 - **Operator-Based Architecture**: 20+ specialized operators organized into 5 categories (Extract, Ingest, Functional, Quality, VectorDB)
 - **PyArrow Data Format**: All data flows through the pipeline as PyArrow tables, ensuring efficient memory usage and interoperability
-- **DAG-Based Workflow Execution**: Flows are defined as JSON configurations representing directed acyclic graphs (DAGs) of operator nodes
+- **DAG-Based Workflow Execution**: Flows are defined as JSON configurations representing directed acyclic graphs (DAGs) of operator steps (see [`docs/guides/FLOW_AUTHORING_FORMAT.md`](docs/guides/FLOW_AUTHORING_FORMAT.md))
 - **Prefect Orchestration**: The orchestrator layer uses Prefect for managing workflow execution, parallel processing, and task dependencies
 - **Modern AI/ML Integrations**: Native support for Ollama (LLM operations), Docling (document processing), and OpenSearch (vector storage)
 - **Multi-Provider Support**: Flexible ingest operators supporting local files, S3, CSV, and multi-provider sources
@@ -161,7 +161,7 @@ When coordinating flow-related tasks, delegate to Code mode for:
 - **Flow execution**: `docling-pipelines --flow-file <path>`
 - **Flow validation**: Validate flows before execution
 - **Test execution**: Run pytest with proper environment setup
-- **Flow structure**: JSON files with nodes (operators) and edges (data flow)
+- **Flow structure**: Follows canonical DAG format defined in [`docs/guides/FLOW_AUTHORING_FORMAT.md`](docs/guides/FLOW_AUTHORING_FORMAT.md) and [`sample_flows/`](sample_flows/)
 
 For detailed execution instructions, see [USER_GUIDE_PIPELINE_SETUP.md](USER_GUIDE_PIPELINE_SETUP.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,26 @@
 [project]
 name = "docling-pipelines"
-version = "1.0.0"
+dynamic = ["version"]
 description = "This repository contains the docpipe operators."
 requires-python = ">=3.12,<3.13"
+maintainers = [
+    { name = "Jojo Joseph", email = "jjojo@in.ibm.com" },
+    { name = "Aditya Rohan Singh", email = "adityars@ibm.com" },
+    { name = "Anudeep Dunaboyina", email = "anudeep.dunaboyina@ibm.com" },
+    { name = "Ashok Kumar Angadi", email = "asangadi@in.ibm.com" },
+    { name = "Harshad Nehate", email = "Harshad.Nehate@ibm.com" },
+    { name = "Kurian Kevin", email = "Kurian.Kevin@ibm.com" },
+    { name = "Nipun Bayas", email = "nipun.bayas@ibm.com" },
+    { name = "Paul Baby", email = "Paul.Baby1@ibm.com" },
+    { name = "Prasad Madugundu", email = "smadugun@in.ibm.com" },
+    { name = "Remya P", email = "remya.p@ibm.com" },
+    { name = "Sahil Berwal", email = "Sahil.Berwal@ibm.com" },
+    { name = "Sanchit Rote", email = "Sanchit.Rote@ibm.com" },
+    { name = "Yash Bopardikar", email = "ybopard@us.ibm.com" },
+    { name = "Benson Fernandes", email = "benferna@in.ibm.com" },
+    { name = "Manish Soni", email = "Manish.Soni3@ibm.com" },
+    { name = "Docling Pipeline Team", email = "docling_pipeline_team-dg@ibm.com" },
+]
 dependencies = [
     "accelerate==1.13.0",
     "aiohttp==3.14.1",
@@ -265,8 +283,11 @@ module = [
 ignore_missing_imports = true
 follow_imports = "silent"
 
+[tool.hatch.version]
+source = "vcs"
+
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [dependency-groups]


### PR DESCRIPTION
## Issue
- N/A

## Dev Tracking
- N/A

## Description
Sets up automated PyPI publishing for `docling-pipelines` using GitHub Actions with OIDC Trusted Publishing (no API token required). Also adds maintainer metadata to `pyproject.toml` and switches to dynamic versioning driven by Git tags.

**Changes:**
- `.github/workflows/pypi.yml` — new workflow that triggers on GitHub Release publication, builds the package with `uv build`, and publishes to PyPI using `pypa/gh-action-pypi-publish`
- `pyproject.toml` — adds `maintainers` list (all team members + distribution group), switches `version` to `dynamic` via `hatch-vcs` so the PyPI version is driven by the Git release tag, adds `hatch-vcs` to `[build-system]`
- `AGENTS.md` — updated

## Basic Checklist
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality
- [x] Documentation updated (see Documentation Update Checklist below)
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
- `hatch-vcs` added to `[build-system].requires` — build-time only, not a runtime dependency

## Testing Details
- Pre-commit hooks passed on all changed files
- Workflow can be validated by creating a GitHub Release with a semver tag (e.g. `v1.0.0`)

## Documentation Update Checklist
- [x] N/A - No documentation updates needed

### Pre-Commit Hook Results
```
uv-export................................................................Passed
nbstripout...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
ruff (legacy alias)..................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
Detect secrets...........................................................Passed
```