### PR TITLE
docs: add fasttext-wheel build failure troubleshooting entry for macOS 15+

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -182,6 +182,59 @@ uv sync --extra dev
 
 ---
 
+#### Issue: `fasttext-wheel` Build Failure on macOS 15+ (Sequoia / Tahoe)
+
+**Symptoms:**
+
+```
+× Failed to build `fasttext-wheel==0.9.2`
+...
+fatal error: 'istream' file not found
+error: command '/usr/bin/c++' failed with exit code 1
+```
+
+**Cause:**
+
+`fasttext-wheel` 0.9.2 compiles a C++ extension from source. On macOS 15+ with clang 17, the
+compiler no longer resolves the C++ standard library headers at the deployment target hardcoded
+by `fasttext-wheel` (`-mmacosx-version-min=11.0`). No pre-built binary is available for arm64.
+
+**Solution:**
+
+Set these environment variables before running `uv sync`:
+
+```bash
+CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+CXXFLAGS="-isysroot $(xcrun --show-sdk-path) -mmacosx-version-min=14.0" \
+uv sync --extra dev
+```
+
+To avoid setting these every time, add them to a `.envrc` in the project root (if you use
+[direnv](https://direnv.net/)) or to your `~/.zshrc`:
+
+```bash
+export CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+export CXXFLAGS="-isysroot $(xcrun --show-sdk-path) -mmacosx-version-min=14.0"
+```
+
+**Verify Xcode CLT is installed:**
+
+```bash
+xcode-select --print-path
+# Expected: /Library/Developer/CommandLineTools
+
+xcrun --show-sdk-path
+# Expected: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+```
+
+If `xcode-select` prints nothing, install the tools first:
+
+```bash
+xcode-select --install
+```
+
+---
+
 #### Issue: Permission Denied During Setup
 
 **Symptoms:**


### PR DESCRIPTION
## Description
Documents the `fasttext-wheel` C++ build failure that occurs on macOS 15+ (Sequoia / Tahoe) with clang 17, where the compiler can't locate standard library headers due to a hardcoded deployment target in the package. Provides the `CPLUS_INCLUDE_PATH` and `CXXFLAGS` workaround required to successfully run `uv sync --extra dev` on affected systems.

## Basic Checklist
- [ ] Code follows project standards (keyword-only arguments, no unicode in logging)
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (see Documentation Update Checklist below)
- [ ] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
None

## Testing Details
N/A

## Documentation Update Checklist
<!-- Check all documentation files that were updated or reviewed for this PR -->
- [ ] README.md (if adding features, changing structure, or modifying setup)
- [ ] ARCHITECTURE.md (if modifying operators, data flow, or system design)
- [ ] CONTRIBUTING.md (if changing development workflow or code standards)
- [ ] USER_GUIDE_PIPELINE_SETUP.md (if changing installation, setup, or execution)
- [ ] QUICKSTART.md (if changing quick start steps or examples)
- [ ] OPERATOR_REFERENCE.md (if adding/modifying operators)
- [x] TROUBLESHOOTING.md (if discovering new issues or solutions)
- [ ] Operator documentation in docs/operators/ (if operator added/modified)
- [ ] N/A - No documentation updates needed

## Screenshots/Videos
<!-- For UI changes, include screenshots or videos demonstrating the changes -->
<!-- If not applicable, remove this section -->

### Pre-Commit Hook Results
<!-- Paste the output of pre-commit hooks execution to verify all checks passed -->


### Note
 1. **Keyword Arguments** - Ensure function arguments are keyword-based, not positional - [Link](https://docs.python.org/3/glossary.html#term-argument)
 2. **Metadata Independence:** When adding or modifying operator metadata, ensure the data does not depend on instance variables.
 3. **Method Requirements:** Ensure `get_metadata` is a static method. If `get_required_features` depends on instance variables, the operator must implement `get_static_required_features` using the default values referenced in `get_required_features`
 4. For every PR, ensure that the pre-commit hook output has been included.