### PR TITLE
feat(docling-serve): support v2 artifact response format in DoclingServeAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,38 +66,38 @@ Log verbosity is controlled via `DS_LOG_LEVEL` (`DEBUG`, `INFO`, `WARNING`).
 
 ## Documentation
 
-Check out the full [documentation](docs/README.md) for installation, flow authoring, operator reference, and more:
+Check out the full [documentation](https://github.com/IBM/docling-pipelines/blob/main/docs/README.md) for installation, flow authoring, operator reference, and more:
 
-- [Quick Start Guide](QUICKSTART.md) — first pipeline in under 5 minutes
-- [Pipeline Setup Guide](USER_GUIDE_PIPELINE_SETUP.md) — complete setup with Ollama, OpenSearch, and flow examples
-- [Flow Authoring Format](docs/guides/FLOW_AUTHORING_FORMAT.md) — declarative flow authoring
-- [Operator Reference](docs/reference/OPERATORS.md) — full parameter specs for all operators
-- [Architecture](ARCHITECTURE.md) — system design and distributed execution patterns
-- [Troubleshooting](TROUBLESHOOTING.md) — common issues and solutions
+- [Quick Start Guide](https://github.com/IBM/docling-pipelines/blob/main/QUICKSTART.md) — first pipeline in under 5 minutes
+- [Pipeline Setup Guide](https://github.com/IBM/docling-pipelines/blob/main/USER_GUIDE_PIPELINE_SETUP.md) — complete setup with Ollama, OpenSearch, and flow examples
+- [Flow Authoring Format](https://github.com/IBM/docling-pipelines/blob/main/docs/guides/FLOW_AUTHORING_FORMAT.md) — declarative flow authoring
+- [Operator Reference](https://github.com/IBM/docling-pipelines/blob/main/docs/reference/OPERATORS.md) — full parameter specs for all operators
+- [Architecture](https://github.com/IBM/docling-pipelines/blob/main/ARCHITECTURE.md) — system design and distributed execution patterns
+- [Troubleshooting](https://github.com/IBM/docling-pipelines/blob/main/TROUBLESHOOTING.md) — common issues and solutions
 
 ## Available Operators
 
 | Category | Operators |
 |---|---|
-| **Ingest** | Local File Ingest (`ingest_local`), Remote Source Ingest (`ingest_source`) — [S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, CSV, web](docs/operators/ingest_source/README.md) |
+| **Ingest** | Local File Ingest (`ingest_local`), Remote Source Ingest (`ingest_source`) — [S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, CSV, web](https://github.com/IBM/docling-pipelines/blob/main/docs/operators/ingest_source/README.md) |
 | **Extract** | Document Extractor (`extract_operator`), ACL Extraction (`acl_operator`) |
 | **Functional** | Chunking (`chunker`), Embeddings (`embeddings`), Branching Operator (`branching`), Merge Operator (`merge`), Document ID Hash (`doc_id_hash`), Entity Curation (`entity_curation`), No-op (`noop`) |
 | **Quality** | Language Annotator (`lang_detect`), Readability Operator (`readability`), PII and HAP Annotator (`pii_and_hap`), Document Classifier (`document_classifier`), Annotation Filter (`sql_filter`), Redaction (`redaction`), De-duplicator (`ededup`), ML Text Enrichment (`ml_enrichment`), Document Quality (`doc_quality`) |
 | **VectorDB** | Vector Database (`vectordb`) — OpenSearch, Milvus |
 | **Storage** | Document Set (`document_set`) — DuckDB-backed document collections |
 
-For per-operator configuration guides, see [Operator Configuration Guides](docs/reference/OPERATORS.md).
+For per-operator configuration guides, see [Operator Configuration Guides](https://github.com/IBM/docling-pipelines/blob/main/docs/reference/OPERATORS.md).
 
 ## Examples
 
-Explore [sample flows](examples/) and [DocpipeFlowManager examples](examples/docpipe_flow_manager/) for common pipeline patterns.
+Explore [sample flows](https://github.com/IBM/docling-pipelines/tree/main/examples/) and [DocpipeFlowManager examples](https://github.com/IBM/docling-pipelines/tree/main/examples/docpipe_flow_manager/) for common pipeline patterns.
 
-For interactive, hands-on tutorials, see the [Jupyter notebook examples](examples/notebooks/README.md).
+For interactive, hands-on tutorials, see the [Jupyter notebook examples](https://github.com/IBM/docling-pipelines/blob/main/examples/notebooks/README.md).
 
 ## Contributing
 
-Please read [Contributing to Docling pipelines](CONTRIBUTING.md) for development setup, code standards, testing requirements, and the pull request process.
+Please read [Contributing to Docling pipelines](https://github.com/IBM/docling-pipelines/blob/main/CONTRIBUTING.md) for development setup, code standards, testing requirements, and the pull request process.
 
 ## License
 
-The Docling pipelines codebase is under the [MIT License](LICENSE).
+The Docling pipelines codebase is under the [MIT License](https://github.com/IBM/docling-pipelines/blob/main/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ dynamic = ["version"]
 description = "This repository contains the docpipe operators."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
+
+[project.urls]
+Homepage = "https://github.com/IBM/docling-pipelines"
+Documentation = "https://github.com/IBM/docling-pipelines/blob/main/docs/README.md"
+Source = "https://github.com/IBM/docling-pipelines"
+"Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
 maintainers = [
     { name = "Jojo Joseph", email = "jjojo@in.ibm.com" },
     { name = "Aditya Rohan Singh", email = "adityars@ibm.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,6 @@ dynamic = ["version"]
 description = "This repository contains the docpipe operators."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
-
-[project.urls]
-Homepage = "https://github.com/IBM/docling-pipelines"
-Documentation = "https://github.com/IBM/docling-pipelines/blob/main/docs/README.md"
-Source = "https://github.com/IBM/docling-pipelines"
-"Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
 maintainers = [
     { name = "Jojo Joseph", email = "jjojo@in.ibm.com" },
     { name = "Aditya Rohan Singh", email = "adityars@ibm.com" },
@@ -28,6 +22,13 @@ maintainers = [
     { name = "Manish Soni", email = "Manish.Soni3@ibm.com" },
     { name = "Docling Pipeline Team", email = "docling_pipeline_team-dg@ibm.com" },
 ]
+
+[project.urls]
+Homepage = "https://github.com/IBM/docling-pipelines"
+Documentation = "https://github.com/IBM/docling-pipelines/blob/main/docs/README.md"
+Source = "https://github.com/IBM/docling-pipelines"
+"Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
+
 dependencies = [
     "accelerate==1.13.0",
     "aiohttp==3.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,6 @@ maintainers = [
     { name = "Docling Pipeline Team", email = "docling_pipeline_team-dg@ibm.com" },
 ]
 
-[project.urls]
-Homepage = "https://github.com/IBM/docling-pipelines"
-Documentation = "https://github.com/IBM/docling-pipelines/blob/main/docs/README.md"
-Source = "https://github.com/IBM/docling-pipelines"
-"Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
-
 dependencies = [
     "accelerate==1.13.0",
     "aiohttp==3.14.1",
@@ -149,6 +143,12 @@ vlm_asr = [
 [project.scripts]
 docling-pipelines-api = "docpipe.api.main:app"
 docling-pipelines = "docpipe.cli.docpipe_cli:main"
+
+[project.urls]
+Homepage = "https://github.com/IBM/docling-pipelines"
+Documentation = "https://github.com/IBM/docling-pipelines/blob/main/docs/README.md"
+Source = "https://github.com/IBM/docling-pipelines"
+"Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/docpipe"]

--- a/src/docpipe/core/constants/operator_constants.py
+++ b/src/docpipe/core/constants/operator_constants.py
@@ -520,6 +520,16 @@ class OperatorConstants:
         OUTPUT_FORMAT_DOCTAGS: Final[str] = "doctags"
         OUTPUT_FORMAT_DOCLANG: Final[str] = "doclang"
 
+        # Docling Serve API response keys
+        DOCLING_SERVE_DOCUMENT: Final[str] = "document"
+        DOCLING_SERVE_PROCESSING_TIME: Final[str] = "processing_time"
+        DOCLING_SERVE_PAGES: Final[str] = "pages"
+        DOCLING_SERVE_HTML_CONTENT: Final[str] = "html_content"
+        DOCLING_SERVE_JSON_CONTENT: Final[str] = "json_content"
+        DOCLING_SERVE_TEXT_CONTENT: Final[str] = "text_content"
+        DOCLING_SERVE_DOCTAGS_CONTENT: Final[str] = "doctags_content"
+        DOCLING_SERVE_DOCLANG_CONTENT: Final[str] = "doclang_content"
+
         # Valid output formats list (markdown is always generated, so not in this list)
         VALID_OUTPUT_FORMATS: Final[list[str]] = [
             OUTPUT_FORMAT_HTML,

--- a/src/docpipe/core/operators/extract/adapters/outbound/factories/text_extraction_adapter_factory.py
+++ b/src/docpipe/core/operators/extract/adapters/outbound/factories/text_extraction_adapter_factory.py
@@ -142,7 +142,6 @@ class TextExtractionAdapterFactory:
             )
 
         elif mode == TextExtractionMode.DOCLING_SERVE:
-            # Build docling_serve_config dictionary from provider_config
             docling_serve_config = {
                 OperatorConstants.Config.BASE_URL: provider_config.get(
                     OperatorConstants.Config.BASE_URL, "http://localhost:5001"
@@ -158,13 +157,9 @@ class TextExtractionAdapterFactory:
                     OperatorConstants.Processing.VERIFY_SSL, True
                 ),
                 OperatorConstants.Config.DO_OCR: provider_config.get(OperatorConstants.Config.DO_OCR, True),
-                OperatorConstants.Config.OCR_ENGINE: provider_config.get(
-                    OperatorConstants.Config.OCR_ENGINE, "easyocr"
-                ),
                 OperatorConstants.Config.PDF_BACKEND: provider_config.get(
                     OperatorConstants.Config.PDF_BACKEND, "dlparse_v2"
                 ),
-                OperatorConstants.Config.TABLE_MODE: provider_config.get(OperatorConstants.Config.TABLE_MODE, "fast"),
                 OperatorConstants.Config.IMAGE_EXPORT_MODE: provider_config.get(
                     OperatorConstants.Config.IMAGE_EXPORT_MODE, "placeholder"
                 ),
@@ -174,6 +169,18 @@ class TextExtractionAdapterFactory:
             if provider_config.get(OperatorConstants.Config.API_KEY):
                 docling_serve_config[OperatorConstants.Config.API_KEY] = provider_config[
                     OperatorConstants.Config.API_KEY
+                ]
+
+            # ocr_engine and table_mode are optional — only forward if explicitly set
+            # (different docling-serve versions/deployments support different values)
+            if provider_config.get(OperatorConstants.Config.OCR_ENGINE):
+                docling_serve_config[OperatorConstants.Config.OCR_ENGINE] = provider_config[
+                    OperatorConstants.Config.OCR_ENGINE
+                ]
+
+            if provider_config.get(OperatorConstants.Config.TABLE_MODE):
+                docling_serve_config[OperatorConstants.Config.TABLE_MODE] = provider_config[
+                    OperatorConstants.Config.TABLE_MODE
                 ]
 
             if provider_config.get(OperatorConstants.Config.OCR_LANGUAGES):

--- a/src/docpipe/core/operators/extract/adapters/outbound/text_extraction/docling_serve_adapter.py
+++ b/src/docpipe/core/operators/extract/adapters/outbound/text_extraction/docling_serve_adapter.py
@@ -3,12 +3,18 @@
 This adapter implements remote document extraction using the Docling Serve API.
 It delegates extraction to a remote Docling Serve instance, enabling distributed
 processing and reducing local resource requirements.
+
+Supports two docling-serve response formats:
+- v1 (inline): {"document": {"md_content": "...", ...}, "processing_time": ...}
+- v2 (artifacts): {"documents": [{"artifacts": [{"artifact_type": "markdown", "uri": "..."}]}], ...}
 """
 
 import json
 import logging
 from pathlib import Path
 from typing import Any, ClassVar
+
+import requests
 
 from docpipe.core.constants.operator_constants import OperatorConstants
 from docpipe.core.operators.extract.ports.outbound.text_extraction import TextExtractionPort
@@ -55,13 +61,25 @@ class DoclingServeAdapter(TextExtractionPort):
     ADAPTER_NAME = "docling_serve"
     ADAPTER_DISPLAY_NAME = "Docling Serve Extractor"
 
-    # Maps format name -> docling-serve API response field name.
+    # Maps format name → docling-serve v1 API response field name.
+    # Paired with FORMAT_COLUMN_MAPPING (inherited from TextExtractionPort) this gives
+    # both the source key (API response) and the destination key (PyArrow column).
     FORMAT_API_FIELD_MAPPING: ClassVar[dict[str, str]] = {
-        OperatorConstants.Extraction.OUTPUT_FORMAT_HTML: "html_content",
-        OperatorConstants.Extraction.OUTPUT_FORMAT_JSON: "json_content",
-        OperatorConstants.Extraction.OUTPUT_FORMAT_TEXT: "text_content",
-        OperatorConstants.Extraction.OUTPUT_FORMAT_DOCTAGS: "doctags_content",
-        OperatorConstants.Extraction.OUTPUT_FORMAT_DOCLANG: "doclang_content",
+        OperatorConstants.Extraction.OUTPUT_FORMAT_HTML: OperatorConstants.Extraction.DOCLING_SERVE_HTML_CONTENT,
+        OperatorConstants.Extraction.OUTPUT_FORMAT_JSON: OperatorConstants.Extraction.DOCLING_SERVE_JSON_CONTENT,
+        OperatorConstants.Extraction.OUTPUT_FORMAT_TEXT: OperatorConstants.Extraction.DOCLING_SERVE_TEXT_CONTENT,
+        OperatorConstants.Extraction.OUTPUT_FORMAT_DOCTAGS: OperatorConstants.Extraction.DOCLING_SERVE_DOCTAGS_CONTENT,
+        OperatorConstants.Extraction.OUTPUT_FORMAT_DOCLANG: OperatorConstants.Extraction.DOCLING_SERVE_DOCLANG_CONTENT,
+    }
+
+    # Maps docling-serve v2 artifact_type → format name used in FORMAT_API_FIELD_MAPPING / additional_formats
+    ARTIFACT_TYPE_TO_FORMAT: ClassVar[dict[str, str]] = {
+        "markdown": OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN,
+        "html": OperatorConstants.Extraction.OUTPUT_FORMAT_HTML,
+        "json": OperatorConstants.Extraction.OUTPUT_FORMAT_JSON,
+        "text": OperatorConstants.Extraction.OUTPUT_FORMAT_TEXT,
+        "doctags": OperatorConstants.Extraction.OUTPUT_FORMAT_DOCTAGS,
+        "doclang": OperatorConstants.Extraction.OUTPUT_FORMAT_DOCLANG,
     }
 
     def __init__(self, *, config: dict[str, Any]) -> None:
@@ -93,11 +111,16 @@ class DoclingServeAdapter(TextExtractionPort):
         self.max_retries = docling_serve_config.get("max_retries", 3)
         self.verify_ssl = docling_serve_config.get("verify_ssl", True)
 
-        # Build processing options
-        self.processing_options = {
+        # Build processing options — only include what the user explicitly configured.
+        # Markdown is always sent by the client as the default to_formats value.
+        self.processing_options: dict[str, Any] = {
             "do_ocr": docling_serve_config.get("do_ocr", True),
             "pdf_backend": docling_serve_config.get("pdf_backend", "dlparse_v2"),
         }
+
+        # Pass additional formats through — client will merge with the mandatory "md" default.
+        if self.additional_formats:
+            self.processing_options["additional_formats"] = self.additional_formats
 
         # Add optional parameters if present
         if "ocr_engine" in docling_serve_config:
@@ -109,13 +132,18 @@ class DoclingServeAdapter(TextExtractionPort):
         if "image_export_mode" in docling_serve_config:
             self.processing_options["image_export_mode"] = docling_serve_config["image_export_mode"]
 
-        logger.info("Initialized DoclingServeAdapter with base_url: %s, timeout: %s", self.base_url, self.timeout)
+        logger.info(
+            "Initialized DoclingServeAdapter with base_url: %s, timeout: %s, additional_formats: %s",
+            self.base_url,
+            self.timeout,
+            self.additional_formats,
+        )
 
     def extract_single_document(self, *, file_path: str, binary_content: bytes, **kwargs: Any) -> dict[str, Any]:
         """Extract content from a single document using Docling Serve API.
 
         Sends the document to a remote Docling Serve instance for extraction.
-        Polls for results and returns the extracted markdown content.
+        Polls for results and returns the extracted markdown content plus any additional formats.
 
         Args:
             file_path: Path to the document file (used for logging and filename preservation)
@@ -125,11 +153,16 @@ class DoclingServeAdapter(TextExtractionPort):
         Returns:
             Dictionary containing:
                 - success: True if extraction succeeded
-                - doc_content: Extracted content as markdown
-                - metadata: Extraction metadata (processing_time, page_count, etc.)
+                - content: Extracted content as markdown (mandatory)
+                - content_html: HTML format (if requested in additional_formats)
+                - content_json: JSON format (if requested in additional_formats)
+                - content_text: Plain text format (if requested in additional_formats)
+                - content_doctags: DocTags format (if requested in additional_formats)
+                - content_doclang: DocLang format (if requested in additional_formats)
+                - metadata: Extraction metadata (processing_time, page_count, formats, etc.)
                 - error: Error message if extraction failed
         """
-        logger.info("Processing file with docling-serve: %s", file_path)
+        logger.info("Processing file with docling-serve (formats: md + %s): %s", self.additional_formats, file_path)
 
         try:
             file_suffix = Path(file_path).suffix.lower()
@@ -161,58 +194,31 @@ class DoclingServeAdapter(TextExtractionPort):
                 filename=filename,
                 options=self.processing_options,
             )
-            # Debug: Log the full result structure
-            logger.debug(
-                f"Docling-serve result keys: {list(result.keys()) if isinstance(result, dict) else 'Not a dict'}"
-            )
-            # Extract content from v1 API response format
-            # v1 API returns: {"document": {"md_content": "...", ...}, "processing_time": ..., ...}
-            document = result.get("document", {})
-            logger.info(
-                f"Document object keys: {list(document.keys()) if isinstance(document, dict) else 'Not a dict'}"
-            )
-            markdown_text = document.get("md_content", "")
-            logger.info(f"Extracted markdown length: {len(markdown_text) if markdown_text else 0} for file {file_path}")
 
-            # Build result dictionary starting with mandatory markdown
-            result_dict: dict[str, Any] = {
-                OperatorConstants.Extraction.SUCCESS: True,
-                OperatorConstants.Columns.DOC_COLUMN_DEFAULT: markdown_text,
-            }
+            # Detect response format and extract content accordingly
+            extra_metadata: dict[str, Any] = {}
+            if "documents" in result:
+                # v2 format: artifacts are presigned URIs that must be fetched
+                result_dict, formats_generated = self._extract_from_v2_response(result=result, file_path=file_path)
+            else:
+                # v1 format: content is inline in the response body
+                result_dict, formats_generated, extra_metadata = self._extract_from_v1_response(
+                    result=result, file_path=file_path
+                )
 
-            # Add additional formats if they were requested and are present in response
-            formats_generated = [OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN]
-
-            for fmt in self.additional_formats:
-                if fmt in self.FORMAT_API_FIELD_MAPPING and fmt in OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING:
-                    api_field = self.FORMAT_API_FIELD_MAPPING[fmt]
-                    output_column = OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING[fmt]
-                    if api_field in document:
-                        content = document.get(api_field, "")
-                        # Special handling for JSON format: serialise the dict response to a string
-                        if fmt == OperatorConstants.Extraction.OUTPUT_FORMAT_JSON and content:
-                            content = json.dumps(content, indent=2) if content else ""
-                        result_dict[output_column] = content
-                        formats_generated.append(fmt)
-                        logger.info(f"Generated {fmt} format for {file_path}")
-
-            # Build metadata
+            # Build metadata, merging any extra fields from the response (e.g. page_count)
+            markdown_text = result_dict.get(OperatorConstants.Columns.DOC_COLUMN_DEFAULT, "")
             metadata = {
-                "processing_time": result.get("processing_time", 0),
+                OperatorConstants.Extraction.DOCLING_SERVE_PROCESSING_TIME: result.get(
+                    OperatorConstants.Extraction.DOCLING_SERVE_PROCESSING_TIME, 0
+                ),
                 "char_count": len(markdown_text) if markdown_text else 0,
                 "formats": formats_generated,
+                **extra_metadata,
             }
-
-            # Add page count if available from json_content
-            json_content = document.get("json_content", {})
-            if json_content and isinstance(json_content, dict):
-                pages = json_content.get("pages", {})
-                if pages:
-                    metadata[OperatorConstants.Metadata.PAGE_COUNT] = len(pages)
-
             result_dict[OperatorConstants.Metadata.METADATA] = metadata
 
-            logger.info(f"Completed docling-serve extraction for {file_path} (formats: {formats_generated})")
+            logger.info("Completed docling-serve extraction for %s (formats: %s)", file_path, formats_generated)
             return result_dict
 
         except Exception as e:
@@ -222,3 +228,113 @@ class DoclingServeAdapter(TextExtractionPort):
                 OperatorConstants.Extraction.ERROR: str(e),
                 OperatorConstants.Columns.DOC_COLUMN_DEFAULT: None,
             }
+
+    def _extract_from_v1_response(
+        self, *, result: dict[str, Any], file_path: str
+    ) -> tuple[dict[str, Any], list[str], dict[str, Any]]:
+        """Extract content from v1 inline response format.
+
+        v1 response: {"document": {"md_content": "...", "html_content": "..."}, "processing_time": ...}
+
+        Returns:
+            Tuple of (result_dict, formats_generated, extra_metadata) where extra_metadata
+            contains additional fields (e.g. page_count) to be merged into the final metadata dict.
+        """
+        document = result.get(OperatorConstants.Extraction.DOCLING_SERVE_DOCUMENT, {})
+        logger.debug(
+            "v1 response - document keys: %s",
+            list(document.keys()) if isinstance(document, dict) else "not a dict",
+        )
+
+        result_dict: dict[str, Any] = {
+            OperatorConstants.Extraction.SUCCESS: True,
+            OperatorConstants.Columns.DOC_COLUMN_DEFAULT: document.get("md_content", ""),
+        }
+        formats_generated = [OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN]
+        extra_metadata: dict[str, Any] = {}
+
+        for fmt in self.additional_formats:
+            if fmt in self.FORMAT_API_FIELD_MAPPING and fmt in OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING:
+                api_field = self.FORMAT_API_FIELD_MAPPING[fmt]
+                output_column = OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING[fmt]
+                if api_field in document:
+                    content = document.get(api_field, "")
+                    if fmt == OperatorConstants.Extraction.OUTPUT_FORMAT_JSON and content:
+                        content = json.dumps(content, indent=2) if content else ""
+                    result_dict[output_column] = content
+                    formats_generated.append(fmt)
+                    logger.info("Generated %s format for %s", fmt, file_path)
+
+        # Page count from json_content if present
+        json_content = document.get("json_content", {})
+        if json_content and isinstance(json_content, dict):
+            pages = json_content.get(OperatorConstants.Extraction.DOCLING_SERVE_PAGES, {})
+            if pages:
+                extra_metadata[OperatorConstants.Metadata.PAGE_COUNT] = len(pages)
+
+        return result_dict, formats_generated, extra_metadata
+
+    def _extract_from_v2_response(self, *, result: dict[str, Any], file_path: str) -> tuple[dict[str, Any], list[str]]:
+        """Extract content from v2 artifact URI response format.
+
+        v2 response: {"documents": [{"artifacts": [{"artifact_type": "markdown", "uri": "..."}]}], ...}
+        Content is not inline — each artifact must be fetched from its presigned URI.
+        """
+        documents = result.get("documents", [])
+        logger.debug("v2 response - %d document(s) in result", len(documents))
+
+        result_dict: dict[str, Any] = {
+            OperatorConstants.Extraction.SUCCESS: True,
+            OperatorConstants.Columns.DOC_COLUMN_DEFAULT: "",
+        }
+        formats_generated: list[str] = []
+
+        if not documents:
+            logger.warning("v2 response contains no documents for %s", file_path)
+            return result_dict, [OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN]
+
+        doc = documents[0]
+        artifacts = doc.get("artifacts", [])
+        logger.debug("v2 response - artifact types: %s", [a.get("artifact_type") for a in artifacts])
+
+        # Determine which formats to fetch: always markdown + any requested additional formats
+        requested_formats = {OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN} | set(self.additional_formats)
+
+        for artifact in artifacts:
+            artifact_type = artifact.get("artifact_type", "")
+            fmt = self.ARTIFACT_TYPE_TO_FORMAT.get(artifact_type)
+            if fmt is None or fmt not in requested_formats:
+                continue
+
+            uri = artifact.get("uri", "")
+            if not uri:
+                logger.warning("v2 artifact '%s' has no URI for %s", artifact_type, file_path)
+                continue
+
+            logger.info("Fetching v2 artifact '%s' for %s", artifact_type, file_path)
+            try:
+                resp = requests.get(uri, timeout=60, verify=self.verify_ssl)
+                resp.raise_for_status()
+                content: str = resp.text
+            except Exception as fetch_err:
+                logger.warning("Failed to fetch v2 artifact '%s' for %s: %s", artifact_type, file_path, fetch_err)
+                continue
+
+            if fmt == OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN:
+                result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] = content
+                formats_generated.append(fmt)
+            elif fmt in OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING:
+                output_column = OperatorConstants.Extraction.FORMAT_COLUMN_MAPPING[fmt]
+                if fmt == OperatorConstants.Extraction.OUTPUT_FORMAT_JSON:
+                    try:
+                        content = json.dumps(json.loads(content), indent=2)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                result_dict[output_column] = content
+                formats_generated.append(fmt)
+                logger.info("Generated %s format for %s", fmt, file_path)
+
+        if OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN not in formats_generated:
+            formats_generated.insert(0, OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN)
+
+        return result_dict, formats_generated

--- a/src/docpipe/integrations/docling/client.py
+++ b/src/docpipe/integrations/docling/client.py
@@ -1,5 +1,5 @@
 # Copyright IBM Corp. 2025
-# -License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Docling Serve Client for document processing via REST API.
@@ -9,6 +9,7 @@ processing documents through docling-serve service.
 """
 
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,92 @@ from docpipe.integrations.rest_client import RestClient, RestClientConfig, RestM
 from docpipe.utils.infrastructure.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+class DoclingServeErrorHandler:
+    """
+    Extensible error handler for docling-serve exceptions.
+
+    Each registered handler is a (matcher, enhancer) pair:
+      - matcher(exception) -> bool  : returns True if this handler applies
+      - enhancer(exception, context) -> DocpipeException : returns the enhanced exception
+
+    To add a new error type, call register():
+        handler.register(my_matcher, my_enhancer)
+    """
+
+    def __init__(self, *, base_url: str) -> None:
+        self.base_url = base_url
+        self._handlers: list[
+            tuple[
+                Callable[[DocpipeException], bool],
+                Callable[[DocpipeException, dict[str, Any]], DocpipeException],
+            ]
+        ] = []
+        self._register_defaults()
+
+    def _register_defaults(self) -> None:
+        self.register(self._is_format_compatibility_error, self._enhance_format_compatibility_error)
+
+    def register(
+        self,
+        matcher: Callable[[DocpipeException], bool],
+        enhancer: Callable[[DocpipeException, dict[str, Any]], DocpipeException],
+    ) -> None:
+        """Register a new (matcher, enhancer) pair. Handlers are checked in registration order."""
+        self._handlers.append((matcher, enhancer))
+
+    def handle(self, exception: DocpipeException, context: dict[str, Any] | None = None) -> DocpipeException:
+        """
+        Return an enhanced exception if any registered handler matches, otherwise return the original.
+
+        Args:
+            exception: The exception to classify
+            context: Optional context passed to the enhancer (e.g. requested_formats)
+        """
+        ctx = context or {}
+        for matcher, enhancer in self._handlers:
+            if matcher(exception):
+                return enhancer(exception, ctx)
+        return exception
+
+    # --- built-in handler: format compatibility ---
+
+    @staticmethod
+    def _is_format_compatibility_error(exception: DocpipeException) -> bool:
+        if exception.status_code == 422:
+            return True
+        msg = str(exception).lower()
+        return any(
+            indicator in msg
+            for indicator in (
+                "format",
+                "to_formats",
+                "unsupported",
+                "invalid format",
+                "unknown format",
+                "not supported",
+            )
+        )
+
+    def _enhance_format_compatibility_error(
+        self, exception: DocpipeException, context: dict[str, Any]
+    ) -> DocpipeException:
+        requested_formats = context.get("requested_formats", [])
+        message = (
+            f"The docling-serve instance at {self.base_url} rejected the requested output formats. "
+            f"This typically occurs when using an older docling-serve version that does not support "
+            f"one or more of the requested formats: {requested_formats}. "
+            f"\n\nTo resolve this issue:\n"
+            f"1. Upgrade docling-serve to the latest version, OR\n"
+            f"2. Remove unsupported formats from 'text_extraction.provider_config.additional_formats' in your flow configuration.\n"
+            f"\nOriginal error: {exception}"
+        )
+        return DocpipeException(
+            message=message,
+            status_code=exception.status_code,
+            error_code=ErrorCode.EXTERNAL_SERVICE_ERROR,
+        )
 
 
 class DoclingServeClient:
@@ -73,11 +160,18 @@ class DoclingServeClient:
         if self.api_key:
             self.custom_headers["X-API-KEY"] = self.api_key
 
-        logger.info(f"Initialized DoclingServeClient with base_url={self.base_url}")
+        # Error handler — use register() to add new error types as needed
+        self.error_handler = DoclingServeErrorHandler(base_url=self.base_url)
+
+        logger.info("Initialized DoclingServeClient with base_url=%s", self.base_url)
 
     def _build_options(self, options: dict[str, Any] | None = None) -> dict[str, Any]:
         """
-        Build options dictionary with defaults for v1 API.
+        Build options dictionary with safe defaults for the docling-serve v1 API.
+
+        Defaults cover parameters that are universally supported across docling-serve
+        deployments. Parameters that vary by deployment (ocr_engine, table_mode) are
+        NOT included as defaults — they must be explicitly set by the caller.
 
         Args:
             options: User-provided options to override defaults
@@ -85,24 +179,44 @@ class DoclingServeClient:
         Returns:
             Complete options dictionary with defaults applied
         """
-        default_options = {
+        default_options: dict[str, Any] = {
             "do_ocr": True,
             "ocr_preset": "auto",
-            "ocr_lang": None,
             "pdf_backend": "dlparse_v2",
-            "table_mode": "accurate",
             "do_table_structure": True,
             "table_cell_matching": True,
             "include_images": True,
             "images_scale": 2.0,
-            "image_export_mode": "embedded",
-            "to_formats": ["json", "md", "text", "doclang"],
+            "image_export_mode": "placeholder",
+            # Markdown is mandatory, additional formats come from options
+            "to_formats": ["md"],
         }
 
         if options:
-            default_options.update(options)
+            # Work on a copy so we never mutate the caller's dict (processing_options on the adapter
+            # is reused across every document — mutating it would lose additional_formats after the first call)
+            opts = dict(options)
 
-        return default_options
+            # Pull out additional_formats and append to to_formats before merging the rest
+            additional_formats = opts.pop("additional_formats", None)
+            if additional_formats:
+                to_formats_list: list[str] = default_options["to_formats"]  # type: ignore[assignment]
+                for fmt in additional_formats:
+                    if fmt and fmt not in to_formats_list:
+                        to_formats_list.append(fmt)
+
+            # Pull out any explicit to_formats override before the general update
+            user_to_formats = opts.pop("to_formats", None)
+            default_options.update(opts)
+
+            if user_to_formats:
+                # Ensure "md" is always present
+                if "md" not in user_to_formats:
+                    user_to_formats.insert(0, "md")
+                default_options["to_formats"] = user_to_formats
+
+        # Strip None values — requests serialises None as the string "None" which the server rejects
+        return {k: v for k, v in default_options.items() if v is not None}
 
     def submit_document(
         self,
@@ -142,12 +256,12 @@ class DoclingServeClient:
                 raise FileNotFoundError(f"File not found: {file_path}")
             content = path.read_bytes()
             actual_filename = path.name
-            logger.info(f"Submitting document: {file_path}")
+            logger.info("Submitting document: %s", file_path)
         else:
             # binary_content is guaranteed to be bytes here due to validation above
             content = binary_content  # type: ignore[assignment]
             actual_filename = filename if filename else OperatorConstants.Extraction.DEFAULT_FALLBACK_FILENAME
-            logger.info(f"Submitting document from binary content with filename: {actual_filename}")
+            logger.info("Submitting document from binary content with filename: %s", actual_filename)
 
         # Submit request using multipart/form-data
         endpoint = "/v1/convert/file/async"
@@ -206,13 +320,18 @@ class DoclingServeClient:
         # Build form data with options as individual fields
         data = self._build_options(options)
 
-        result = self.rest_client.call_rest_multipart(
-            method=RestMethod.POST,
-            endpoint=endpoint,
-            files=files,
-            data=data,
-            headers=self.custom_headers,
-        )
+        try:
+            result = self.rest_client.call_rest_multipart(
+                method=RestMethod.POST,
+                endpoint=endpoint,
+                files=files,
+                data=data,
+                headers=self.custom_headers,
+            )
+        except DocpipeException as e:
+            context = {"requested_formats": data.get("to_formats", [])}
+            enhanced = self.error_handler.handle(e, context)
+            raise enhanced from e
 
         task_id = result.get("task_id")
         if not task_id:
@@ -222,7 +341,7 @@ class DoclingServeClient:
                 error_code=ErrorCode.EXTERNAL_SERVICE_ERROR,
             )
 
-        logger.info(f"Document submitted successfully, task_id={task_id}")
+        logger.info("Document submitted successfully, task_id=%s, params=%s", task_id, list(data.keys()))
         return task_id
 
     def _poll_for_completion(
@@ -251,7 +370,7 @@ class DoclingServeClient:
         interval = poll_interval if poll_interval is not None else self.poll_interval
         start_time = time.time()
 
-        logger.info(f"Polling status for task_id={task_id} with timeout={timeout}s")
+        logger.info("Polling status for task_id=%s with timeout=%ss", task_id, timeout)
 
         while True:
             elapsed = time.time() - start_time
@@ -268,16 +387,22 @@ class DoclingServeClient:
                 task_status = result.get("task_status", "unknown").upper()
                 file_label = filename if filename is not None else "unknown"
 
-                logger.info(f"Polling task {task_id} for file '{file_label}': status={task_status}")
+                logger.info("Polling task %s for file '%s': status=%s", task_id, file_label, task_status)
 
                 if task_status == "SUCCESS":
-                    logger.info(f"Task {task_id} completed successfully")
+                    logger.info("Task %s completed successfully", task_id)
                     return result
 
                 if task_status == "FAILURE":
                     error_msg = result.get("error_message", "Unknown error")
                     logger.error(
-                        f"Task {task_id} failed with error: {error_msg}",
+                        "Task %s failed with error: %s. "
+                        "If this is an 'Internal processing error', check that the processing "
+                        "parameters sent to docling-serve are supported by this deployment "
+                        "(e.g. ocr_engine, table_mode, pdf_backend). "
+                        "See the submission log above for the params that were sent.",
+                        task_id,
+                        error_msg,
                         extra={"task_id": task_id, "full_response": result},
                     )
                     raise DocpipeException(
@@ -287,7 +412,7 @@ class DoclingServeClient:
                     )
 
                 # Continue polling for PENDING/STARTED/unknown statuses
-                logger.debug(f"Task {task_id} status: {task_status}, continuing to poll...")
+                logger.debug("Task %s status: %s, continuing to poll...", task_id, task_status)
                 time.sleep(interval)
 
             except DocpipeException as e:
@@ -295,7 +420,7 @@ class DoclingServeClient:
                 if e.error_code != ErrorCode.CONNECTION_ERROR:
                     raise
                 # For connection errors, log and retry
-                logger.warning(f"Connection error during polling: {e}, retrying...")
+                logger.warning("Connection error during polling: %s, retrying...", e)
                 time.sleep(interval)
 
     def poll_status(
@@ -359,8 +484,8 @@ class DoclingServeClient:
             # Only retry on 404 errors (task not found during pod transitions)
             if e.status_code == 404:
                 logger.warning(
-                    f"Task not found (404) at {endpoint}. "
-                    f"This may occur during pod restarts or HPA scaling. Retrying..."
+                    "Task not found (404) at %s. This may occur during pod restarts or HPA scaling. Retrying...",
+                    endpoint,
                 )
                 raise  # Let decorator handle retry
             # For other errors, raise immediately without retry
@@ -380,7 +505,7 @@ class DoclingServeClient:
             DocpipeException: For HTTP or network errors
         """
         endpoint = f"/v1/result/{task_id}"
-        logger.info(f"Retrieving result for task_id={task_id}")
+        logger.info("Retrieving result for task_id=%s", task_id)
 
         result = self.rest_client.call_rest_json(
             method=RestMethod.GET,
@@ -388,7 +513,7 @@ class DoclingServeClient:
             headers=self.custom_headers,
         )
 
-        logger.info(f"Result retrieved successfully for task_id={task_id}")
+        logger.info("Result retrieved successfully for task_id=%s", task_id)
         return result
 
     def process_document(
@@ -436,9 +561,9 @@ class DoclingServeClient:
             timeout=timeout,
             filename=filename,
         )
-        logger.info(f"Final Status before: {task_id}, {final_response}")
+        logger.info("Final status response for task_id=%s: %s", task_id, final_response)
         final_status = str(final_response.get("task_status", "")).upper()
-        logger.info(f"Final Status: {task_id}, {final_status}")
+        logger.info("Final status for task_id=%s: %s", task_id, final_status)
         if final_status != "SUCCESS":
             error_message = final_response.get("error_message", "Unknown Error")
             raise DocpipeException(

--- a/tests/unit/common/clients/test_docling_serve_client.py
+++ b/tests/unit/common/clients/test_docling_serve_client.py
@@ -416,3 +416,142 @@ class TestDoclingServeClient:
         )
         mock_get_result.assert_called_once_with(task_id="test-task-123")
         assert result["document"] == "processed"
+
+
+class TestDoclingServeErrorHandler:
+    """Test suite for DoclingServeErrorHandler."""
+
+    def _make_exception(self, *, message: str = "error", status_code: int = 500) -> DocpipeException:
+        return DocpipeException(message=message, status_code=status_code, error_code=ErrorCode.EXTERNAL_SERVICE_ERROR)
+
+    def test_handle_returns_original_when_no_match(self):
+        """Unrecognised exceptions are returned unchanged."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://localhost:5001")
+        exc = self._make_exception(message="some random error", status_code=500)
+        result = handler.handle(exc)
+        assert result is exc
+
+    def test_handle_matches_422_status_code(self):
+        """HTTP 422 triggers the format compatibility handler."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://localhost:5001")
+        exc = self._make_exception(message="unprocessable entity", status_code=422)
+        result = handler.handle(exc, context={"requested_formats": ["html", "json"]})
+        assert result is not exc
+        assert "422" not in str(result) or "docling-serve" in str(result)
+        assert "additional_formats" in str(result)
+
+    def test_handle_matches_format_keyword_in_message(self):
+        """Exception messages containing format-related keywords trigger the handler."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://localhost:5001")
+        for keyword in ("format", "to_formats", "unsupported", "invalid format", "unknown format", "not supported"):
+            exc = self._make_exception(message=f"something about {keyword}", status_code=400)
+            result = handler.handle(exc)
+            assert result is not exc, f"Expected handler to match keyword: {keyword}"
+
+    def test_enhance_format_compatibility_error_message_content(self):
+        """Enhanced error message references the base_url and requested formats."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://myserver:5001")
+        exc = self._make_exception(message="bad format", status_code=422)
+        result = handler.handle(exc, context={"requested_formats": ["html", "doctags"]})
+        msg = str(result)
+        assert "http://myserver:5001" in msg
+        assert "html" in msg
+        assert "doctags" in msg
+        assert "additional_formats" in msg
+
+    def test_handle_no_match_with_empty_context(self):
+        """handle() with no context dict does not crash."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://localhost:5001")
+        exc = self._make_exception(message="generic error", status_code=503)
+        result = handler.handle(exc)
+        assert result is exc
+
+    def test_register_custom_handler(self):
+        """Custom (matcher, enhancer) pair is invoked when matcher returns True."""
+        from docpipe.integrations.docling.client import DoclingServeErrorHandler
+
+        handler = DoclingServeErrorHandler(base_url="http://localhost:5001")
+
+        def my_matcher(e: DocpipeException) -> bool:
+            return e.status_code == 503
+
+        def my_enhancer(e: DocpipeException, ctx: dict) -> DocpipeException:
+            return DocpipeException(
+                message="service unavailable — custom",
+                status_code=503,
+                error_code=ErrorCode.EXTERNAL_SERVICE_ERROR,
+            )
+
+        handler.register(my_matcher, my_enhancer)
+        exc = self._make_exception(message="service down", status_code=503)
+        result = handler.handle(exc)
+        assert "custom" in str(result)
+
+
+class TestBuildOptionsMutationFix:
+    """Tests that _build_options does not mutate the caller's options dict."""
+
+    def test_build_options_does_not_mutate_input_dict(self):
+        """Calling _build_options twice with the same dict must not lose additional_formats."""
+        from docpipe.integrations.docling.client import DoclingServeClient
+
+        client = DoclingServeClient(base_url="http://localhost:5001")
+        options = {"do_ocr": True, "pdf_backend": "dlparse_v2", "additional_formats": ["html", "json"]}
+        original_keys = set(options.keys())
+
+        # Call twice — second call must produce same result as first
+        result1 = client._build_options(options)
+        result2 = client._build_options(options)
+
+        assert set(options.keys()) == original_keys, "Input dict was mutated"
+        assert result1["to_formats"] == result2["to_formats"], "Results differ between calls"
+
+    def test_build_options_additional_formats_merged_into_to_formats(self):
+        """additional_formats values are appended to to_formats in the built options."""
+        from docpipe.integrations.docling.client import DoclingServeClient
+
+        client = DoclingServeClient(base_url="http://localhost:5001")
+        options = {"additional_formats": ["html", "text"]}
+        result = client._build_options(options)
+
+        assert "md" in result["to_formats"]
+        assert "html" in result["to_formats"]
+        assert "text" in result["to_formats"]
+        assert "additional_formats" not in result
+
+    def test_build_options_md_always_present(self):
+        """to_formats always contains 'md' even when not explicitly specified."""
+        from docpipe.integrations.docling.client import DoclingServeClient
+
+        client = DoclingServeClient(base_url="http://localhost:5001")
+        result = client._build_options()
+        assert "md" in result["to_formats"]
+
+    def test_build_options_strips_none_values(self):
+        """None values are stripped from the built options dict."""
+        from docpipe.integrations.docling.client import DoclingServeClient
+
+        client = DoclingServeClient(base_url="http://localhost:5001")
+        options = {"ocr_lang": None, "do_ocr": True}
+        result = client._build_options(options)
+        assert "ocr_lang" not in result
+
+    def test_build_options_no_duplicate_formats(self):
+        """The same format is not added twice to to_formats."""
+        from docpipe.integrations.docling.client import DoclingServeClient
+
+        client = DoclingServeClient(base_url="http://localhost:5001")
+        options = {"additional_formats": ["md", "html", "html"]}
+        result = client._build_options(options)
+        assert result["to_formats"].count("md") == 1
+        assert result["to_formats"].count("html") == 1

--- a/tests/unit/operators/extract/adapters/outbound/text_extraction/test_docling_serve_adapter.py
+++ b/tests/unit/operators/extract/adapters/outbound/text_extraction/test_docling_serve_adapter.py
@@ -622,3 +622,187 @@ class TestDoclingServeAdapter:
         config = {"docling_serve_config": {"base_url": "http://localhost:5001"}}
         adapter = DoclingServeAdapter(config=config)
         assert adapter.verify_ssl is True
+
+
+class TestDoclingServeAdapterV2Response:
+    """Tests for _extract_from_v2_response (docling-serve artifact URI format)."""
+
+    @pytest.fixture
+    def adapter(self):
+        return DoclingServeAdapter(
+            config={
+                "docling_serve_config": {
+                    "base_url": "http://localhost:5001",
+                    "timeout": 300,
+                    "poll_interval": 2,
+                    "max_retries": 3,
+                }
+            }
+        )
+
+    @pytest.fixture
+    def adapter_with_html(self):
+        return DoclingServeAdapter(
+            config={
+                "docling_serve_config": {
+                    "base_url": "http://localhost:5001",
+                    "timeout": 300,
+                    "poll_interval": 2,
+                    "max_retries": 3,
+                },
+                "additional_formats": ["html"],
+            }
+        )
+
+    def _make_v2_result(self, artifacts: list) -> dict:
+        return {"documents": [{"artifacts": artifacts}]}
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_extracts_markdown(self, mock_get, adapter):
+        """Happy path: markdown artifact URI is fetched and stored as doc content."""
+        mock_get.return_value = MagicMock(text="# Hello World", raise_for_status=MagicMock())
+        result = {"documents": [{"artifacts": [{"artifact_type": "markdown", "uri": "https://s3/md"}]}]}
+
+        result_dict, formats = adapter._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        mock_get.assert_called_once_with("https://s3/md", timeout=60, verify=True)
+        assert result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == "# Hello World"
+        assert OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN in formats
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_fetches_additional_format(self, mock_get, adapter_with_html):
+        """Additional format (html) URI is fetched and stored in the correct column."""
+        mock_get.side_effect = [
+            MagicMock(text="# Markdown", raise_for_status=MagicMock()),
+            MagicMock(text="<h1>HTML</h1>", raise_for_status=MagicMock()),
+        ]
+        result = {
+            "documents": [
+                {
+                    "artifacts": [
+                        {"artifact_type": "markdown", "uri": "https://s3/md"},
+                        {"artifact_type": "html", "uri": "https://s3/html"},
+                    ]
+                }
+            ]
+        }
+
+        result_dict, formats = adapter_with_html._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        assert result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == "# Markdown"
+        assert result_dict[OperatorConstants.Columns.CONTENT_HTML] == "<h1>HTML</h1>"
+        assert OperatorConstants.Extraction.OUTPUT_FORMAT_HTML in formats
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_skips_unrequested_formats(self, mock_get, adapter):
+        """Artifacts for formats not requested are not fetched."""
+        mock_get.return_value = MagicMock(text="# Markdown", raise_for_status=MagicMock())
+        result = {
+            "documents": [
+                {
+                    "artifacts": [
+                        {"artifact_type": "markdown", "uri": "https://s3/md"},
+                        {"artifact_type": "html", "uri": "https://s3/html"},
+                    ]
+                }
+            ]
+        }
+
+        _result_dict, formats = adapter._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        # html was not requested — only one fetch for markdown
+        assert mock_get.call_count == 1
+        assert OperatorConstants.Extraction.OUTPUT_FORMAT_HTML not in formats
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_skips_artifact_with_missing_uri(self, mock_get, adapter):
+        """Artifact with empty URI is skipped gracefully without crashing."""
+        result = {"documents": [{"artifacts": [{"artifact_type": "markdown", "uri": ""}]}]}
+
+        result_dict, _formats = adapter._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        mock_get.assert_not_called()
+        assert result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == ""
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_failed_fetch_is_skipped(self, mock_get, adapter):
+        """A fetch error on an artifact is logged and skipped; extraction continues."""
+        mock_get.side_effect = Exception("network error")
+        result = {"documents": [{"artifacts": [{"artifact_type": "markdown", "uri": "https://s3/md"}]}]}
+
+        result_dict, _formats = adapter._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        assert result_dict[OperatorConstants.Extraction.SUCCESS] is True
+        assert result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == ""
+
+    def test_v2_response_empty_documents_list(self, adapter):
+        """v2 response with no documents returns empty markdown content."""
+        result = {"documents": []}
+
+        result_dict, formats = adapter._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        assert result_dict[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == ""
+        assert OperatorConstants.Extraction.OUTPUT_FORMAT_MARKDOWN in formats
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.requests.get")
+    def test_v2_response_json_artifact_is_serialised(self, mock_get, adapter):
+        """JSON artifact content is parsed and re-serialised to a string."""
+        adapter_json = DoclingServeAdapter(
+            config={
+                "docling_serve_config": {"base_url": "http://localhost:5001"},
+                "additional_formats": ["json"],
+            }
+        )
+        mock_get.side_effect = [
+            MagicMock(text="# Markdown", raise_for_status=MagicMock()),
+            MagicMock(text='{"key": "value"}', raise_for_status=MagicMock()),
+        ]
+        result = {
+            "documents": [
+                {
+                    "artifacts": [
+                        {"artifact_type": "markdown", "uri": "https://s3/md"},
+                        {"artifact_type": "json", "uri": "https://s3/json"},
+                    ]
+                }
+            ]
+        }
+
+        result_dict, _formats = adapter_json._extract_from_v2_response(result=result, file_path="doc.pdf")
+
+        json_col = OperatorConstants.Columns.CONTENT_JSON
+        assert json_col in result_dict
+        import json
+
+        parsed = json.loads(result_dict[json_col])
+        assert parsed["key"] == "value"
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.DoclingServeClient")
+    def test_extract_single_document_routes_to_v2_when_documents_key_present(self, mock_client_class, adapter):
+        """extract_single_document uses v2 path when 'documents' key is in the API response."""
+        mock_instance = MagicMock()
+        mock_instance.process_document.return_value = {
+            "documents": [{"artifacts": [{"artifact_type": "markdown", "uri": ""}]}],
+            "processing_time": 1.0,
+        }
+        mock_client_class.return_value = mock_instance
+
+        result = adapter.extract_single_document(file_path="doc.pdf", binary_content=b"data")
+
+        assert result[OperatorConstants.Extraction.SUCCESS] is True
+        assert OperatorConstants.Metadata.METADATA in result
+
+    @patch("docpipe.core.operators.extract.adapters.outbound.text_extraction.docling_serve_adapter.DoclingServeClient")
+    def test_extract_single_document_routes_to_v1_when_document_key_present(self, mock_client_class, adapter):
+        """extract_single_document uses v1 path when 'document' key is in the API response."""
+        mock_instance = MagicMock()
+        mock_instance.process_document.return_value = {
+            "document": {"md_content": "# V1 Content"},
+            "processing_time": 0.8,
+        }
+        mock_client_class.return_value = mock_instance
+
+        result = adapter.extract_single_document(file_path="doc.pdf", binary_content=b"data")
+
+        assert result[OperatorConstants.Extraction.SUCCESS] is True
+        assert result[OperatorConstants.Columns.DOC_COLUMN_DEFAULT] == "# V1 Content"


### PR DESCRIPTION
## Issue
Resolves #7

## Dev Tracking

N/A

## Description

The `DoclingServeAdapter` previously only handled the docling-serve **v1 inline response format**. Newer deployments (e.g. Docling SaaS) return a **v2 artifact URI format** where each output format is a presigned URI that must be fetched separately. This PR adds full v2 support alongside several related robustness fixes.

**1. v2 artifact URI response support (`DoclingServeAdapter`)**
- Auto-detects response format: `documents` key present → v2, otherwise → v1
- New `_extract_from_v2_response()`: iterates artifacts, fetches each presigned URI via `requests.get`, maps `artifact_type` → output column
- New `_extract_from_v1_response()`: refactored out of `extract_single_document` for clarity
- New `ARTIFACT_TYPE_TO_FORMAT` class-level mapping

**2. `ocr_engine` and `table_mode` made optional (`TextExtractionAdapterFactory`)**
- Previously always forwarded with hardcoded defaults (`"easyocr"`, `"fast"`) causing 422s on some deployments
- Now only forwarded if explicitly set by the user

**3. `DoclingServeErrorHandler` (`DoclingServeClient`)**
- Extensible (matcher, enhancer) handler pattern for classifying docling-serve exceptions
- Built-in handler for format compatibility errors (HTTP 422 or format-related message keywords) with actionable error messages
- Pluggable via `handler.register(matcher, enhancer)`

**4. `_build_options` mutation fix (`DoclingServeClient`)**
- Previously mutated the shared `processing_options` dict, losing `additional_formats` after the first document in a batch
- Now works on a copy; `additional_formats` merged into `to_formats` before the update
- `to_formats` always includes `"md"`; `None` values stripped before sending

**5. Constant hygiene (`operator_constants.py`)**
- New `DOCLING_SERVE_*` constants replacing raw strings in the adapter

**6. README + `pyproject.toml` link fixes**
- Relative doc links converted to absolute GitHub URLs for correct PyPI rendering
- Added `[project.urls]` block to `pyproject.toml`

## Basic Checklist
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality
- [x] Documentation updated (see Documentation Update Checklist below)
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes

None — v1 response handling is fully preserved; v2 detection is additive.

## Dependencies

None — `requests` was already a transitive dependency; it is now used directly in the adapter.

## Testing Details

**Unit tests — 20 new tests, all passing:**
```
pytest tests/unit/common/clients/test_docling_serve_client.py::TestDoclingServeErrorHandler        tests/unit/common/clients/test_docling_serve_client.py::TestBuildOptionsMutationFix        tests/unit/operators/extract/adapters/outbound/text_extraction/test_docling_serve_adapter.py::TestDoclingServeAdapterV2Response        -v
# 20 passed in 6.64s
```

**Integration flow — v1 (local docling-serve, inline response format):**

Flow: `test_flows/docling_local_serve_extract.json`
- Ingested 3 invoice PDFs from `tests/fixtures/invoices`
- Extraction via `DoclingServeAdapter` against `http://localhost:5001` (v1 response path)
- All 3 documents extracted successfully via the `_extract_from_v1_response` path
- Chunked into 20 chunks, embedded with `nomic-embed-text`, stored in OpenSearch index `docling-local-serve-test`
- Result: `docling_extract` — Duration: 21s | Documents: 3 processed, 0 failed, 0 skipped

**Integration flow — v2 (Docling SaaS, artifact URI response format):**

Flow: `test_flows/docling_saas_v2_extract.json`
- Same 3 invoice PDFs
- Extraction via `DoclingServeAdapter` against Docling SaaS (v2 artifact URI response path)
- The new `_extract_from_v2_response` path was exercised end-to-end: `Fetching v2 artifact 'markdown'` confirmed for all 3 documents
- Chunked, embedded, stored in OpenSearch index `docling-saas-test`
- Result: `docling_extract` — Duration: 24s | Documents: 3 processed, 0 failed, 0 skipped

## Documentation Update Checklist
- [x] README.md (absolute GitHub URLs added for PyPI rendering)
- [ ] ARCHITECTURE.md
- [ ] CONTRIBUTING.md
- [ ] USER_GUIDE_PIPELINE_SETUP.md
- [ ] QUICKSTART.md
- [ ] OPERATOR_REFERENCE.md
- [ ] TROUBLESHOOTING.md
- [ ] Operator documentation in docs/operators/
- [x] N/A - No other documentation updates needed

## Screenshots/Videos

N/A

### Pre-Commit Hook Results

```
uv-export................................................................Passed
nbstripout...........................................(no files to check)Skipped
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
mypy.....................................................................Passed
Detect secrets...........................................................Passed
```

### Note
1. **Keyword Arguments** - All new/modified function signatures use keyword-only arguments (`*` separator).
2. **Metadata Independence** - No operator metadata changes in this PR.
3. **Method Requirements** - No new operators introduced.
4. Pre-commit hook output included above.