### PR TITLE
fix: bump pyasn1 0.6.3 -> 0.6.4 (CVE-2026-59884)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "prefect==3.7.1",
     "psycopg2-binary==2.9.12",
     "pyarrow==24.0.0",
-    "pyasn1==0.6.3",
+    "pyasn1==0.6.4",  # CVE-2026-59884: Security fix for pyasn1 BER/CER/DER decoder DoS
     "pydantic==2.12.5",
     "pydantic-settings==2.14.0",
     "pygments==2.20.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -208,7 +208,7 @@ psutil==7.2.2
 psycopg2-binary==2.9.12
 py-key-value-aio==0.4.4
 pyarrow==24.0.0
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1-modules==0.4.2
 pybind11==3.0.4
 pyclipper==1.4.0

--- a/uv.lock
+++ b/uv.lock
@@ -1167,7 +1167,6 @@ wheels = [
 
 [[package]]
 name = "docling-pipelines"
-version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -1305,8 +1304,8 @@ requires-dist = [
     { name = "datatrove", specifier = "==0.3.0" },
     { name = "datefinder", specifier = "==1.0.0" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = "==1.5.0" },
+    { name = "docling", extras = ["asr", "vlm"], marker = "extra == 'vlm-asr'" },
     { name = "docling", extras = ["rapidocr"], specifier = "==2.105.0" },
-    { name = "docling", extras = ["vlm", "asr"], marker = "extra == 'vlm-asr'" },
     { name = "duckdb", specifier = "==1.3.2" },
     { name = "faker", marker = "extra == 'dev'", specifier = "==40.8.0" },
     { name = "fastapi", specifier = "==0.136.3" },
@@ -1358,7 +1357,7 @@ requires-dist = [
     { name = "prefect", specifier = "==3.7.1" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "pyarrow", specifier = "==24.0.0" },
-    { name = "pyasn1", specifier = "==0.6.3" },
+    { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.14.0" },
     { name = "pygments", specifier = "==2.20.0" },
@@ -4475,11 +4474,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- No associated issue — security advisory fix -->

## Dev Tracking
<!-- N/A -->

## Description
Bumps `pyasn1` from `0.6.3` to `0.6.4` to address **GHSA-m4p7-r5rc-7g4j / CVE-2026-59884**.

**Advisory summary:** The BER/CER/DER decoder in `pyasn1 < 0.6.4` parses long-form tags with no upper bound on tag ID size, allowing a crafted ~1 MB input to consume over a minute of CPU (quadratic cost). On Python 3.11+, an oversized tag ID can additionally trigger an unhandled `ValueError` during error-message formatting, violating the documented `PyAsn1Error` contract and potentially bypassing caller error handling.

- **Severity:** High (CVSS 7.5)
- **Affected versions:** `< 0.6.4`
- **Fixed in:** `0.6.4`
- **Reference:** https://github.com/advisories/GHSA-m4p7-r5rc-7g4j

## Basic Checklist
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality — N/A (dependency version bump only)
- [x] Documentation updated — N/A
- [x] No breaking changes

## Breaking Changes
None — `pyasn1 0.6.4` is a patch release. The only behavioural change is that oversized BER tag IDs (> 20 octets) are now rejected with `PyAsn1Error` instead of consuming unbounded CPU.

## Dependencies
| Package | Old | New | Reason |
|---|---|---|---|
| `pyasn1` | `0.6.3` | `0.6.4` | CVE-2026-59884 security fix |

## Testing Details
- `uv lock` resolved successfully with `pyasn1 v0.6.3 -> v0.6.4`
- `requirements.txt` regenerated via `uv-export` pre-commit hook

## Documentation Update Checklist
- [x] N/A - No documentation updates needed

### Pre-Commit Hook Results
```
uv-export................................................................Passed
nbstripout...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
ruff (legacy alias)..................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
Detect secrets...........................................................Passed
Your commit was protected by Block Secrets powered by IBM Vault Radar.
```