### PR TITLE
chore: add agent skills and CLAUDE.md

### DIFF
--- a/.skills/docpipe-custom-operator/SKILL.md
+++ b/.skills/docpipe-custom-operator/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: docpipe-custom-operator
+description: >-
+  Create, load, package, or modify an external custom operator for docpipe. Use when a consumer
+  needs an AbstractOperator supplied through DOCPIPE_CUSTOM_OPERATORS, DocpipeFlowManager,
+  package entry points, S3, or register_operator_provider without modifying the built-in
+  DOCPIPE_OPERATORS registry. Do not use for built-in operators or ingest source connectors.
+---
+
+# Docpipe Custom Operator
+
+Deliver a consumer-owned operator that satisfies docpipe’s PyArrow and metadata contracts, is discoverable through the selected custom loading mechanism, and runs in a valid flow without modifying the built-in registry.
+
+## Scope and placement
+
+A custom operator is external to `src/docpipe` and must set:
+
+```python
+owner: str | None = DocpipeConstants.OWNER_CUSTOM
+```
+
+Custom discovery rejects an operator that claims `OWNER_DOCPIPE`. Do not import the class into `src/docpipe/core/operators/operator_registry.py` and do not add it to `DOCPIPE_OPERATORS`.
+
+Choose a consumer-owned location. When adding a maintained example to this repository, use `examples/custom_operators/`; otherwise use the user’s external project or requested path.
+
+Read these sources before implementing:
+
+- `src/docpipe/core/operators/abstract_operator.py` for the runtime contract;
+- `src/docpipe/core/orchestration/operator_loader/validator.py` for discovery validation;
+- `examples/custom_operators/hello_operator.py` for a small current example;
+- `docs/guides/CUSTOM_OPERATORS_GUIDE.md` for filesystem, package, and S3 loading;
+- `docs/guides/EXTERNAL_OPERATOR_INTEGRATION.md` only for host provider hooks and owner-priority behavior.
+
+Read [references/examples.md](references/examples.md) and select the example matching the requested loading mode and operator shape. Do not load package or S3 examples for a simple local-file operator.
+
+## Choose the loading mode
+
+Use the smallest mechanism that fits distribution needs.
+
+### Local file or directory
+
+Use during development. `DOCPIPE_CUSTOM_OPERATORS` accepts comma-separated source paths:
+
+```bash
+export DOCPIPE_CUSTOM_OPERATORS="/absolute/path/operator.py,/absolute/path/operators"
+```
+
+The filesystem loader scans Python modules and validates discovered classes. Prefer one operator class per module so discovery is deterministic.
+
+### Installed package
+
+Use for reuse across applications. Put operators in an importable package, expose a stable module, and optionally publish `docpipe.operators` entry points. Verify both package installation metadata and module import; the package adapter uses both entry points and module inspection.
+
+### Python library registration
+
+Call before execution:
+
+```python
+manager.register_custom_operators(package_names=["my_company.operators"])
+```
+
+### Host application provider
+
+Use `register_operator_provider()` when a host application owns a set of operator classes and wires them at startup. Return a `frozenset` and optionally filter it by orchestrator. Register owner priority only when the host intentionally needs conflict resolution beyond the reserved custom and docpipe tiers.
+
+### S3 source
+
+Use only for an existing remote-operator deployment workflow. Keep credentials outside source paths, use the supported S3 loader configuration, and do not download or execute untrusted operator code.
+
+## Required class contract
+
+Implement a class that:
+
+- inherits `AbstractOperator`;
+- defines non-empty `short_name` and a valid `OperatorCategory`;
+- sets `owner = DocpipeConstants.OWNER_CUSTOM`;
+- calls `super().__init__(config)` when overriding `__init__`;
+- defines `transform()` directly on the class;
+- accepts a `pa.Table` and returns `tuple[list[pa.Table], dict]`;
+- implements `get_metadata()` as `@staticmethod` for its public parameters and output features;
+- declares upstream columns with `get_required_features()`;
+- uses `create_base_metadata()` and inherited failure/skip recording;
+- keeps persistence, orchestration, and concrete infrastructure adapters outside transform logic.
+
+Use keyword-only parameters whenever a function has two or more parameters excluding `self` or `cls`. Do not copy the legacy optional `file_name` argument from old examples unless a real caller requires it; make it keyword-only when required.
+
+## Transform semantics
+
+Define before coding:
+
+- required columns and accepted Arrow types;
+- output columns, types, and whether existing columns are replaced;
+- row ordering, document identifier, and branch behavior;
+- empty-table, missing-column, null-value, and row-failure behavior;
+- processed, skipped, and failed metadata accounting.
+
+For valid zero-row input, return an empty output with a stable schema unless the operator’s documented contract requires failure. Never use `if table:` on `pa.Table`.
+
+Use docpipe ports such as `LLMInferencePort` or `LLMEmbeddingPort` for external behavior. Inject or construct dependencies at an appropriate boundary; do not make transform logic import a concrete built-in adapter.
+
+## Metadata and validation
+
+Keep the runtime configuration and `get_metadata()` synchronized.
+
+- Put user inputs under `OperatorConstants.Config.ATTRIBUTES` with label, description, type, required flag, default, and bounds or valid values.
+- Put produced columns under `OperatorConstants.Config.FEATURES` with stable names and types.
+- Use `AttributeDataTypes` and existing constants instead of free-form strings when available.
+- Implement `get_static_required_features()` when discovery needs requirements without instance configuration.
+- Override `validate(errors, warnings, available_features)` for cross-field and upstream-feature validation.
+- Ensure the class `short_name`, flow `type`, metadata, tests, and docs agree.
+
+## Logging and safety
+
+- Use `get_logger()` from docpipe infrastructure.
+- Use lazy `%s` parameters in `logger.*()` calls; no f-strings.
+- Do not log secrets, full document content, or non-ASCII/emoji text.
+- Preserve actionable document identifiers and job context in errors.
+- Treat imported custom code as executable code; do not load an untrusted path or package merely to inspect it.
+
+## Verify discovery before flow execution
+
+For a local source:
+
+```bash
+source .venv/bin/activate
+DOCPIPE_CUSTOM_OPERATORS=/absolute/path/to/operator.py \
+  docling-pipelines --list-operators --verbose
+```
+
+Confirm:
+
+- the expected `short_name` is present;
+- owner is `custom`;
+- category, availability, attributes, and features are correct;
+- no duplicate short name exists in the same custom load batch;
+- an intended override wins according to owner priority.
+
+An importable module that is absent from `--list-operators` is not complete.
+
+## Automated verification
+
+Keep tests with the consumer project. For an example maintained here, place focused tests under an appropriate `tests/unit/` custom-loader or example area without changing global registries during teardown.
+
+Cover at least:
+
+- happy-path output schema and exact values;
+- typed zero-row input;
+- invalid and conflicting config;
+- missing and null required columns;
+- row-level or dependency failures and metadata accounting;
+- discovery validation, owner, and duplicate `short_name` behavior;
+- package/provider registration when that loading mode is used.
+
+Mock external services and use `patch.object` or injected dependencies. Reuse `tests/fixtures/custom_operators/` for loader behavior when appropriate.
+
+## Runnable flow validation
+
+Create a temporary flow with exactly one `ingest_source` root, the minimum upstream operators required by the custom operator, and the custom `short_name` as its `type`. Use `force_ingest: true`, keep validation enabled, and set micro-batching explicitly for deterministic behavior.
+
+Validate and run with the same custom source configuration:
+
+```bash
+source .venv/bin/activate
+DOCPIPE_CUSTOM_OPERATORS=/absolute/path/to/operator.py \
+  docling-pipelines --flow-file /path/to/flow.json --validate
+
+DOCPIPE_CUSTOM_OPERATORS=/absolute/path/to/operator.py \
+  docling-pipelines --flow-file /path/to/flow.json
+```
+
+Use `.skills/feature-testing-workflow/SKILL.md` to inspect job statistics and actual Parquet values without depending on pytest. Verify feature values, input/output document parity, and failure/skip counts rather than relying only on process exit status.
+
+## Packaging and documentation
+
+For a distributable package:
+
+- provide normal package metadata and a stable import path;
+- declare compatible docpipe/Python versions;
+- declare only required dependencies;
+- add `docpipe.operators` entry points when package discovery needs them;
+- document the selected loading mechanism and required environment variables;
+- verify behavior in a clean environment where the package is installed rather than imported from the working tree.
+
+For a repository example, update `examples/custom_operators/README.md`, add or update one focused example flow, and add the change under `## [Unreleased]` in `CHANGELOG.md`. Do not add an external operator to built-in operator reference pages as though it ships with docpipe.
+
+Finish by reporting the source location, loading mode, discovery evidence, flow-validation result, runtime feature evidence, and any unverified external dependency.

--- a/.skills/docpipe-custom-operator/references/examples.md
+++ b/.skills/docpipe-custom-operator/references/examples.md
@@ -1,0 +1,70 @@
+# Custom Operator Examples
+
+Use this map to select one implementation and one loading example. The current skill contract and repository rules take precedence over legacy signatures or logging found in older examples.
+
+## Minimal local operator
+
+Use for an operator that adds one deterministic column and has no external dependency.
+
+- Implementation: `examples/custom_operators/hello_operator.py`
+- Flow: `sample_flows/custom_operators/hello_operator.json`
+- Loader fixture: `tests/fixtures/custom_operators/valid_operator.py`
+- Invalid discovery fixtures: `tests/fixtures/custom_operators/invalid_operator_no_short_name.py` and `invalid_operator_no_transform.py`
+
+The hello example demonstrates `AbstractOperator`, `OWNER_CUSTOM`, Arrow column creation, metadata, and required features. Its optional legacy `file_name` argument is not required for new operators; follow the keyword-only and transform-signature rules in `SKILL.md`.
+
+## Configurable local operator
+
+Use for multiple input parameters, selected columns, or a configurable output column.
+
+- Implementation: `examples/custom_operators/example_custom_operator.py`
+- Flow: `sample_flows/custom_operators/custom_operators_demo.json`
+- Usage guide: `examples/custom_operators/README.md`
+
+Compare `__init__` defaults with `get_metadata()` defaults. Prefer `OperatorConstants` and `AttributeDataTypes` where current built-in operators use them.
+
+## Installed package and entry points
+
+Use when operators will be installed and shared between applications.
+
+- Package root: `examples/custom_operators/package_example/`
+- Package metadata: `examples/custom_operators/package_example/pyproject.toml`
+- Entry-point declaration: `[project.entry-points."docpipe.operators"]` in that file
+- Operators: `my_custom_operators/operators/uppercase_operator.py` and `reverse_operator.py`
+- Package instructions: `examples/custom_operators/package_example/README.md`
+- Loader implementation: `src/docpipe/core/orchestration/operator_loader/adapters/package_adapter.py`
+- Loader tests: `tests/unit/core/orchestrator/operator_loader/test_package_adapter.py`
+
+Verify the installed distribution rather than relying on a repository-relative import. Test entry-point discovery and module inspection because the package adapter supports both.
+
+## Filesystem discovery
+
+Use for a Python file or directory referenced by `DOCPIPE_CUSTOM_OPERATORS`.
+
+- Adapter: `src/docpipe/core/orchestration/operator_loader/adapters/filesystem_adapter.py`
+- Tests: `tests/unit/core/orchestration/operator_loader/adapters/test_filesystem_adapter.py`
+- Loader orchestration: `src/docpipe/core/orchestration/operator_loader/loader_service.py`
+- Loader tests: `tests/unit/core/orchestration/operator_loader/test_loader_service.py`
+
+Use one custom operator class per module when possible. The validator warns and selects the first class when a module contains multiple operator subclasses.
+
+## S3-loaded operator
+
+Use only for an established remote-code workflow.
+
+- Adapter: `src/docpipe/core/orchestration/operator_loader/adapters/s3_adapter.py`
+- Tests: `tests/unit/core/orchestration/operator_loader/adapters/test_s3_adapter.py`
+- Alternate test location: `tests/unit/core/orchestrator/operator_loader/test_s3_adapter.py`
+- Configuration guidance: the S3 section of `docs/guides/CUSTOM_OPERATORS_GUIDE.md`
+
+Remote Python is executable code. Validate the trusted bucket/key boundary and avoid using this example for ordinary document ingestion; ingest sources use `DocumentSourcePort` instead.
+
+## Validation and priority behavior
+
+- Structural validator: `src/docpipe/core/orchestration/operator_loader/validator.py`
+- Validator tests: `tests/unit/core/orchestrator/operator_loader/test_validator.py`
+- Priority resolution: `src/docpipe/core/orchestration/operator_factory.py`
+- Factory tests: `tests/unit/core/orchestrator/test_operator_factory.py`
+- Host provider hooks: `docs/guides/EXTERNAL_OPERATOR_INTEGRATION.md`
+
+Use these references for duplicate `short_name`, incorrect owner, missing transform, custom-over-built-in behavior, and application-specific priority tiers.

--- a/.skills/docpipe-ingest-source-adapter/SKILL.md
+++ b/.skills/docpipe-ingest-source-adapter/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: docpipe-ingest-source-adapter
+description: >-
+  Add or modify an ingest document source provider for IngestSourceOperator. Use when creating
+  its Pydantic configuration, DocumentSourcePort adapter, factory registration, lazy binary
+  retrieval, provider tests, runnable flow, dependency and documentation updates. Do not use
+  for ordinary transform operators or storage destination adapters.
+---
+
+# Docpipe Ingest Source Adapter
+
+Deliver a source provider that is discoverable by `SourceAdapterFactory`, streams domain `Document` metadata efficiently, and can retrieve binary content later for extraction.
+
+## Confirm that a new adapter is needed
+
+Inspect `SourceAdapterFactory._ALIASES` and existing providers first. Add an alias when the requested service is protocol-compatible with an existing adapter and only needs different endpoint configuration. Create a new adapter when authentication, listing, metadata, filtering, download semantics, or service APIs materially differ.
+
+Select the closest reference implementation:
+
+- filesystem-like local traversal: `filesystem`;
+- object storage and pagination: `s3`;
+- generic page retrieval: `web`;
+- Microsoft Graph: `sharepoint` or `onedrive`;
+- OAuth/service API with export formats: `google_drive`;
+- SDK-based SaaS storage: `box`.
+
+Read `docs/guides/CREATE_CONNECTOR_GUIDE.md`, the selected adapter, its tests, and `src/docpipe/core/operators/ingest/ports/outbound/document_source.py` before editing.
+
+Use [references/reference-implementations.md](references/reference-implementations.md) to choose the closest adapter, tests, and runnable flow. Read only the provider family relevant to the requested connector.
+
+## Required files
+
+Create:
+
+```text
+src/docpipe/core/operators/ingest/adapters/outbound/sources/<provider>/
+├── __init__.py
+├── config.py
+└── adapter.py
+```
+
+Add authentication helpers only when they encapsulate reusable provider-specific authentication. Do not create empty layers or duplicate the shared REST, secret, or AWS utilities.
+
+## Configuration model
+
+Define a Pydantic `BaseModel` in `config.py` that represents the adapter’s resolved runtime configuration.
+
+- Separate non-secret `connection_params` from `credentials` at the flow boundary.
+- Validate required fields, ranges, URLs, concurrency limits, and mutually exclusive options.
+- Normalize file extensions to lowercase with a leading dot.
+- Support `max_files` and filtering settings relevant to the provider.
+- Keep credentials out of schema examples, repr output when practical, errors, and logs.
+- Resolve environment-variable references while building config, not by hardcoding secrets into the flow.
+- Do not perform network calls in Pydantic validators.
+
+Add a dependency to `pyproject.toml` only when the shared `RestClient` or an existing dependency cannot implement the provider cleanly. Pin it consistently with project policy and verify the lockfile impact.
+
+## Adapter contract
+
+Decorate the concrete class with `@register_source_adapter` and inherit `DocumentSourcePort[ProviderConfig]`. Define:
+
+- `SOURCE_NAME`: exact flow `provider` value;
+- `SOURCE_DISPLAY_NAME`;
+- `SOURCE_DESCRIPTION`;
+- `SOURCE_VERSION`.
+
+Implement every port method.
+
+### `build_config_from_operator_params()`
+
+Map `connection_params`, `credentials`, `included_extensions`, and `max_files` into the Pydantic configuration. Use keyword-only arguments exactly as declared by the port. Resolve environment references through existing helpers and raise actionable `ValueError` messages for missing user configuration.
+
+### `test_connection()`
+
+Perform the cheapest read-only request that proves authentication and target access. Return `(False, actionable_message)` for expected authentication, permission, not-found, throttling, and connection failures. Avoid downloading full documents.
+
+### `fetch_documents()`
+
+Implement an async generator that yields `docpipe.core.operators.ingest.domain.models.Document` objects incrementally.
+
+- Paginate or stream; do not load an unbounded remote listing into memory.
+- Apply provider-side filters when available, then enforce extension, hidden-file, empty-file, size, exclusion, and `max_files` semantics locally as needed.
+- Use bounded concurrency and deterministic output ordering when downloading metadata concurrently.
+- Populate stable `id`, `name`, `source_url`, timestamps, MIME type, size, extension, ACL, and provider metadata.
+- Prefer metadata-only discovery with `content=b""`; binary content is fetched on demand.
+- Preserve enough information in `source_url`, `id`, or metadata for later retrieval.
+- Treat per-document failures consistently: log safely and continue only when the provider contract permits partial success.
+
+### `fetch_binary_content()`
+
+Retrieve bytes for one document using `source_id`, connection parameters, and credentials. Reuse safe clients or sessions where practical. Return `None` only for documented non-fatal cases; raise clear errors when invalid configuration or connection failure should stop processing. Handle provider-native documents that require export rather than download.
+
+### `get_config_schema()`
+
+Return the Pydantic configuration class. The inherited metadata method uses it for source discovery and UI configuration.
+
+## Registration
+
+Import the adapter class in:
+
+```text
+src/docpipe/core/operators/ingest/adapters/outbound/sources/__init__.py
+```
+
+Add it to `__all__`. This import triggers decorator registration. Do not add source adapters to `DOCPIPE_OPERATORS`; the flow still uses the existing `ingest_source` operator.
+
+Ensure `SOURCE_NAME`, the central import, tests, docs, and sample flow all use the identical provider name. Check for collisions before registering.
+
+## Architecture and security
+
+- Keep provider I/O in the adapter and provider-neutral models in the ingest domain.
+- Depend on the `DocumentSourcePort` abstraction; do not make the domain import this adapter.
+- Use `get_logger()` and lazy `%s` arguments, with no f-strings or non-ASCII log text.
+- Never log tokens, credentials, signed URLs, authorization headers, or full document content.
+- Reuse `RestClient` retry and timeout behavior for HTTP providers unless the SDK already supplies equivalent controls.
+- Bound retries and concurrency; honor throttling signals and avoid retrying permanent authentication failures.
+- Do not make a unit test contact the live provider.
+
+## Unit verification
+
+Create `tests/unit/operators/ingest/test_<provider>_source_adapter.py` and separate config tests when the model is substantial. Cover:
+
+- required fields, normalization, defaults, invalid bounds, and secret resolution;
+- adapter metadata and returned config schema;
+- mapping from operator parameters to provider config;
+- successful and failed `test_connection()` responses;
+- pagination, filtering, ordering, `max_files`, and empty listings;
+- async document generation and complete domain metadata;
+- transient and per-document error behavior;
+- successful binary retrieval, export behavior, not found, permission denied, and malformed `source_id`;
+- factory registration and creation by `SOURCE_NAME`.
+
+Mock the SDK client or `RestClient` object with `patch.object`/injection. Use `@pytest.mark.asyncio` for async adapter methods and collect the async generator explicitly.
+
+Run at least:
+
+```bash
+source .venv/bin/activate
+pytest tests/unit/operators/ingest/test_<provider>_source_adapter.py -v
+pytest tests/unit/operators/ingest/test_source_adapter_factory.py -v
+```
+
+Also run `tests/unit/utils/operators/test_binary_content_fetcher.py` when binary lookup or provider caching behavior changes.
+
+## Runnable feature validation
+
+Create a temporary flow using the provider:
+
+```json
+{
+  "flow_name": "temporary-provider-validation",
+  "global_config": {
+    "disable_validation": false,
+    "force_ingest": true,
+    "enable_micro_batching": false,
+    "data_storage_type": "local"
+  },
+  "flow": [
+    {
+      "type": "ingest_source",
+      "name": "ingest",
+      "config": {
+        "provider": "<provider>",
+        "connection_params": {},
+        "credentials": {},
+        "max_files": 3
+      }
+    }
+  ]
+}
+```
+
+Reference credentials through environment variables. Add `extract_operator` only when validating lazy binary retrieval. Validate before executing and use an isolated provider folder, prefix, or account resource.
+
+Use `.skills/feature-testing-workflow/SKILL.md` to verify actual row counts, metadata columns, filters, job status, and extracted content without depending on pytest. Mark live-provider checks blocked when credentials or service access are unavailable; do not claim unit mocks prove live connectivity.
+
+## Documentation and completion
+
+- Add provider configuration, credentials, permissions, filters, limits, and examples to the appropriate ingest documentation and `docs/reference/OPERATORS.md`.
+- Add a focused provider README beside existing adapters when that remains the local convention.
+- Add one customer-facing sample flow only when it is safe, credential-placeholder based, and meaningfully distinct.
+- Update setup or security documentation for new dependencies, scopes, environment variables, or network access.
+- Add the change under `## [Unreleased]` in `CHANGELOG.md`.
+
+Run focused tests, Ruff, formatting, relevant MyPy checks, flow validation, factory discovery, and the live feature scenario when access exists. Report unverified provider behavior explicitly.

--- a/.skills/docpipe-ingest-source-adapter/references/reference-implementations.md
+++ b/.skills/docpipe-ingest-source-adapter/references/reference-implementations.md
@@ -1,0 +1,53 @@
+# Ingest Source Reference Implementations
+
+Choose one provider family and study its config, adapter, tests, and flow. Do not combine SDK, Graph, and object-storage patterns unless the requested service genuinely requires them.
+
+## Provider map
+
+| Provider family | Implementation | Primary tests | Best use |
+|---|---|---|---|
+| Local traversal | `sources/filesystem/config.py`, `sources/filesystem/adapter.py` | `tests/unit/operators/ingest/test_filesystem_source_adapter.py` | Path validation, recursion, extension filters, lazy local reads |
+| Object storage | `sources/s3/config.py`, `sources/s3/adapter.py` | `tests/unit/operators/ingest/test_s3_source_adapter.py` | Pagination, prefixes, S3-compatible endpoints, bounded concurrency |
+| Web pages | `sources/web/config.py`, `sources/web/adapter.py` | `tests/unit/operators/ingest/test_web_source_adapter.py` | URL validation, page retrieval, HTML/PDF content types |
+| Google Drive | `sources/google_drive/config.py`, `sources/google_drive/adapter.py` | `tests/unit/operators/ingest/test_google_drive_source_adapter.py`, `test_google_drive_config.py` | Service APIs, native-file export, shared-drive traversal |
+| Microsoft Graph | `sources/onedrive/` and `sources/sharepoint/` | `tests/unit/operators/ingest/test_microsoft_source_adapters.py` | Client credentials, drives/sites, Graph pagination and downloads |
+| SDK-backed SaaS | `sources/box/config.py`, `sources/box/adapter.py`, `sources/box/auth.py` | `tests/unit/operators/ingest/test_box_source_adapter.py` | Provider SDK auth, folders, relative paths, binary downloads |
+
+All source paths above are relative to `src/docpipe/core/operators/ingest/adapters/outbound/sources/`.
+
+## Registration and discovery
+
+- Port: `src/docpipe/core/operators/ingest/ports/outbound/document_source.py`
+- Factory and decorator: `src/docpipe/core/operators/ingest/adapters/outbound/sources/factories/source_factory.py`
+- Central registration imports: `src/docpipe/core/operators/ingest/adapters/outbound/sources/__init__.py`
+- Factory tests: `tests/unit/operators/ingest/test_source_adapter_factory.py`
+
+Use the actual `SOURCE_NAME` as the flow provider. For example, the Box adapter currently registers `box_driver`; do not assume the folder name is always the provider string.
+
+## Lazy-content path
+
+- Domain document: `src/docpipe/core/operators/ingest/domain/models.py`
+- Adapter-to-table conversion: `src/docpipe/core/operators/ingest/ingest_source.py`
+- On-demand lookup: `src/docpipe/utils/operators/binary_content_fetcher.py`
+- Lookup tests: `tests/unit/utils/operators/test_binary_content_fetcher.py`
+- Extraction integration: `tests/integration/test_ingest_extract_integration.py`
+
+For metadata discovery, yield `Document(content=b"")` when the provider supports later retrieval. Ensure the resulting source identifier is sufficient for `fetch_binary_content()` after the initial adapter instance is gone.
+
+## Flow references
+
+- Local baseline: `sample_flows/quickstart/basic_ingest_extract.json`
+- S3 to OpenSearch: `sample_flows/use_cases/s3_to_opensearch.json`
+- Storage-output source/refetch scenarios: files under `sample_flows/storage_output/`
+- S3 integration test: `tests/integration/test_s3_ingest_extract_pipeline.py`
+
+Reduce these flows to `ingest_source` plus the minimum downstream operator. Add `extract_operator` specifically when proving lazy binary retrieval or provider-native export.
+
+## Documentation references
+
+- Connector workflow: `docs/guides/CREATE_CONNECTOR_GUIDE.md`
+- Ingest parameters: the `ingest_source` section of `docs/reference/OPERATORS.md`
+- Existing provider notes: `README.md` files inside each source folder
+- Security practices: `docs/guides/SECURITY_BEST_PRACTICES.md`
+
+Use existing provider READMEs for service-specific scopes and configuration, while following current global documentation and changelog rules for new files.

--- a/.skills/docpipe-operator-development/SKILL.md
+++ b/.skills/docpipe-operator-development/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: docpipe-operator-development
+description: >-
+  Create or modify built-in docpipe operators that ship from src/docpipe. Use when implementing
+  transform behavior, metadata and validation, DOCPIPE_OPERATORS registration, tests, a runnable
+  flow, documentation, and changelog updates. Do not use for externally loaded custom operators
+  or ingest source connectors.
+---
+
+# Built-in Docpipe Operator Development
+
+Deliver a complete built-in operator change that respects the PyArrow data contract, is registered in `DOCPIPE_OPERATORS`, and is verified in isolation and through a runnable flow.
+
+## Scope boundary
+
+Use this skill only when the implementation belongs in this repository and ships with docpipe.
+
+- Set `owner = DocpipeConstants.OWNER_DOCPIPE`.
+- Place it under `src/docpipe/core/operators/<category>/` near the closest operator with similar behavior.
+- Import it and add the class to `DOCPIPE_OPERATORS` in `src/docpipe/core/operators/operator_registry.py`.
+- Never register a built-in through `register_operator_provider()`.
+
+Use `.skills/docpipe-custom-operator/SKILL.md` when a consumer supplies the operator through a file, directory, package, S3 source, or provider hook. Use `.skills/docpipe-ingest-source-adapter/SKILL.md` for new `ingest_source` providers.
+
+## Inspect before implementing
+
+Read:
+
+- `src/docpipe/core/operators/abstract_operator.py`;
+- the closest current operator in the same category;
+- `src/docpipe/core/constants/operator_constants.py` for existing column and config keys;
+- `docs/reference/OPERATORS.md` before changing public parameters;
+- related operator tests and sample flows.
+
+Reuse existing constants, ports, adapters, and PyArrow helpers. Do not introduce a new abstraction until the operator behavior demonstrates a real need.
+
+Read [references/reference-operators.md](references/reference-operators.md) and inspect only the examples matching the new operator’s table shape or dependency pattern.
+
+## Required implementation contract
+
+Every operator must:
+
+- inherit `AbstractOperator`;
+- define non-empty `short_name`, `category`, and `owner = DocpipeConstants.OWNER_DOCPIPE` as class attributes;
+- accept configuration in `__init__` and call `super().__init__(config)`;
+- accept and pass data between operators as `pa.Table`;
+- implement `transform()` returning `tuple[list[pa.Table], dict]`;
+- implement `get_metadata()` as `@staticmethod` when exposing parameters or features;
+- use `self.create_base_metadata(total_docs_count=...)`;
+- record row-level failures and skips with inherited helpers;
+- leave orchestration, persistence, and database access outside operator business logic.
+
+Use keyword-only parameters whenever a function has two or more parameters excluding `self` or `cls`. Do not add a legacy `file_name` parameter unless a real caller requires it; if required, make it keyword-only.
+
+## Transform behavior
+
+Define the table semantics before writing code:
+
+- columns read and their PyArrow types;
+- columns added, replaced, or removed;
+- whether row order and document identifiers are preserved;
+- behavior for empty tables, null values, missing columns, and multiple output branches;
+- whether failures are row-local or abort the entire operation;
+- processed, failed, and skipped metadata accounting.
+
+Return an empty table with a stable schema for valid empty input unless the operator contract explicitly requires an error. Never use `if table:` with `pa.Table`; check `table is not None` and `table.num_rows`.
+
+Use port interfaces for LLM inference, embeddings, text detection, storage, and other external behavior. Do not import concrete adapter implementations into operator business logic.
+
+## Metadata and validation
+
+Operator metadata is the public configuration and feature contract.
+
+- Declare configuration inputs under `OperatorConstants.Config.ATTRIBUTES` with type, requirement, default, description, and bounds or valid values when applicable.
+- Declare output columns under `OperatorConstants.Config.FEATURES` with stable names and types.
+- Keep metadata defaults aligned with `__init__` defaults.
+- Implement `get_required_features()` for upstream columns.
+- Add `get_static_required_features()` when required features depend on instance configuration or discovery needs requirements without instantiation.
+- Override `validate(errors, warnings, available_features)` for cross-field, range, provider, or runtime-availability rules that metadata cannot express.
+- Keep `short_name` identical across the class, metadata, flow `type`, tests, and documentation.
+
+## Logging and errors
+
+- Use `docpipe.utils.infrastructure.logging.get_logger()`.
+- Use lazy `%s` arguments in `logger.*()` calls; no f-strings.
+- Do not put emoji or non-ASCII characters in Python logging statements.
+- Include `extra=self.common_log_arguments` where job context is useful.
+- Preserve actionable error context without logging document content or secrets.
+
+## Registration and discovery verification
+
+```bash
+source .venv/bin/activate
+docling-pipelines --list-operators --verbose
+```
+
+Confirm the `short_name`, owner, category, availability, attributes, and features. A successful import without correct discovery is not completion.
+
+## Verification
+
+Add focused unit tests under the matching `tests/unit/operators/` category. At minimum cover:
+
+- valid table and exact output schema or values;
+- zero-row input with a typed schema;
+- invalid or conflicting configuration;
+- missing required column and null values;
+- a simulated downstream or port failure;
+- processed, skipped, and failed metadata counts;
+- registry membership and discovery through the CLI.
+
+Mock external services in unit tests. Use `@pytest.mark.parametrize` rather than loops for input variants. Follow `docs/guides/TESTING_STANDARDS.md` and reuse fixtures from `tests/conftest.py` before creating duplicates.
+
+Create the smallest valid flow with `ingest_source` as the single root, the minimum upstream chain, and the operator under test. Validate it before execution:
+
+```bash
+source .venv/bin/activate
+docling-pipelines --flow-file /path/to/flow.json --validate
+```
+
+For runtime acceptance without relying on test cases, use `.skills/feature-testing-workflow/SKILL.md` and verify actual Parquet values and job metadata.
+
+## Documentation and completion
+
+- create or update `docs/operators/<category>/<operator_name>_readme.md` using the required section order in `docs/guides/DOCUMENTATION_STYLE_GUIDE.md`;
+- update `docs/reference/OPERATORS.md` without duplicating the full operator README;
+- add or update one focused sample flow when it demonstrates a distinct user scenario.
+
+Every code or documentation change requires an entry under `## [Unreleased]` in `CHANGELOG.md`. Run focused tests, Ruff, formatting, relevant MyPy checks, flow validation, and registration discovery. Report what passed, what was not run, and any required external service.

--- a/.skills/docpipe-operator-development/references/reference-operators.md
+++ b/.skills/docpipe-operator-development/references/reference-operators.md
@@ -1,0 +1,47 @@
+# Built-in Operator References
+
+Choose examples by behavior, not merely by category. Read the implementation, its unit tests, metadata, and one representative flow before starting.
+
+## Behavior map
+
+| Needed behavior | Implementation | Tests | Flow or documentation |
+|---|---|---|---|
+| Pass-through and basic metadata | `src/docpipe/core/operators/functional/noop.py` | `tests/unit/operators/noop/test_noop.py` | `sample_flows/advanced/branching_quality_routing.json` |
+| Add a deterministic identifier column | `src/docpipe/core/operators/functional/doc_id_hash.py` | `tests/unit/operators/doc_id/test_doc_id_hash.py` | Search `sample_flows/` for `doc_id_hash` |
+| Filter rows from JSON criteria | `src/docpipe/core/operators/quality/sql_filter.py` | `tests/unit/operators/filter/test_sql_filter.py` | `sample_flows/advanced/quality_branching_merge_pipeline.json` |
+| Expand documents into chunks | `src/docpipe/core/operators/functional/chunker.py` | `tests/unit/operators/chunker/test_chunker.py` | `sample_flows/advanced/hybrid_chunking.json` |
+| Produce named output branches | `src/docpipe/core/operators/functional/branching_operator.py` | `tests/unit/operators/branching/test_branching_operator.py` | `sample_flows/advanced/branching_quality_routing.json` |
+| Consume and combine branches | `src/docpipe/core/operators/functional/merge.py` | `tests/unit/operators/merge/test_merge.py` | `sample_flows/advanced/quality_branching_merge_pipeline.json` |
+| Use an embedding port/provider | `src/docpipe/core/operators/functional/embeddings/embeddings_operator.py` | `tests/unit/operators/embeddings/test_embeddings_operator.py` | `sample_flows/quickstart/complete_pipeline_ollama.json` |
+| Use LLM-backed classification | `src/docpipe/core/operators/quality/classification/document_classifier.py` | `tests/unit/operators/classify/test_document_classifier.py` | `sample_flows/operators/classification_ollama.json` |
+| Add several typed quality features | `src/docpipe/core/operators/quality/readability/readability_operator.py` | `tests/unit/operators/readability/test_readability.py` | `sample_flows/advanced/quality_branching_merge_pipeline.json` |
+| Write through a destination port | `src/docpipe/core/operators/storage/storage_output_operator.py` | `tests/unit/operators/storage/test_storage_output_operator.py` | `sample_flows/storage_output/processed_content_s3.json` |
+
+Some older implementations contain styles that newer repository rules prohibit. Reuse architecture and table semantics, but apply current keyword-only and lazy-logging requirements from `AGENTS.md` and the skill.
+
+## Metadata and validation references
+
+- Base contract: `src/docpipe/core/operators/abstract_operator.py`
+- Metadata keys: `src/docpipe/core/constants/operator_constants.py`
+- Flow feature propagation: `src/docpipe/core/orchestration/flow_validator.py`
+- Public parameter reference: `docs/reference/OPERATORS.md`
+- Operator documentation structure: `docs/guides/DOCUMENTATION_STYLE_GUIDE.md`
+
+For conditional required columns, compare `get_required_features()`, `get_static_required_features()`, metadata features, and flow-validator behavior rather than changing only one surface.
+
+## Registry references
+
+- Built-in imports and `DOCPIPE_OPERATORS`: `src/docpipe/core/operators/operator_registry.py`
+- Resolution and availability: `src/docpipe/core/orchestration/operator_factory.py`
+- Registry/API visibility: `tests/unit/api/routes/test_operators_routes.py`
+- Factory integration: `tests/integration/test_operator_factory_integration.py`
+
+The class, registry import, frozenset entry, metadata, docs, and flow `type` must use the same `short_name`.
+
+## Test-shape references
+
+- Shared fixtures: `tests/conftest.py`
+- Operator expectations: `docs/guides/TESTING_STANDARDS.md`
+- Generic starting template: `tests/templates/test_operator_template.py`
+
+Treat the template as a checklist, not finished code: replace placeholder `pass` statements with exact schema, value, and metadata assertions, and prefer the closest real operator test for mocking patterns.

--- a/.skills/feature-testing-workflow/SKILL.md
+++ b/.skills/feature-testing-workflow/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: feature-testing-workflow
+description: >-
+  Exercise observable docpipe feature behavior without depending on pytest or existing test
+  cases. Use for operator, pipeline, ingest-provider, orchestration, REST API, or Python API
+  validation by building a small runnable scenario, executing a public entrypoint, checking
+  runtime artifacts or service state, and reporting reproducible evidence. Do not use when the
+  user specifically asks to write automated tests.
+---
+
+# Feature Testing Workflow
+
+Validate a feature through the same public surface a user would exercise. Build a self-contained scenario with its own inputs and acceptance checks; existing unit or integration tests are optional supporting evidence, never a prerequisite.
+
+## Required outcome
+
+Produce a feature-validation bundle containing:
+
+- the behavior being tested and its observable acceptance criteria;
+- minimal test input owned by this run;
+- a flow, API request sequence, or Python runner that exercises the feature;
+- executable verification that does not import pytest;
+- a concise result with commands, evidence, failures, and environmental limitations.
+
+A zero exit code alone is not proof that the feature works.
+
+## Core rules
+
+1. Exercise the narrowest public entrypoint that proves the behavior: CLI flow by default, REST API for route-only features, or `DocpipeFlowManager` for library-only behavior.
+2. Do not require existing tests to pass before running this workflow. Do not create pytest cases unless the user separately requests automated coverage.
+3. Derive current configuration from the implementation, `docs/reference/OPERATORS.md`, `docs/reference/GLOBAL_CONFIG.md`, and the closest current file in `sample_flows/`. Do not reuse stale operator names or parameters from memory.
+4. State the acceptance contract before execution. Every criterion must be observable in output tables, job statistics, API responses, logs, or external service state.
+5. Create run artifacts in a temporary directory. Do not add ad hoc flows to `sample_flows/` or commit generated inputs, credentials, logs, or outputs.
+6. Validate a flow before executing it. Keep `disable_validation` false.
+7. Use real external services only when they are part of the behavior under test. Preflight them, use isolated resource names, and never silently replace the requested provider with a mock or different provider.
+8. Do not expose credentials in generated files, commands, reports, or logs. Reference environment variables from flow configuration.
+9. Do not modify production code while performing a validation-only request. Diagnose failures and report them unless the user also asked for a fix.
+
+## Choose the scenario
+
+### Operator or pipeline behavior
+
+Create the smallest valid DAG that reaches the feature. A flow has exactly one root and that root is an ingest operator.
+
+- Start with `ingest_source` using the filesystem provider and one to three small documents when local input is sufficient.
+- Add only the upstream operators needed to produce required columns.
+- Put the operator under test immediately after those prerequisites.
+- Add a downstream operator only when downstream compatibility is part of the acceptance contract.
+- Do not automatically add Chunker, Embeddings, or VectorDB.
+
+### Ingest source provider
+
+Use `ingest_source` with the provider under test. Verify discovery, filtering, document metadata, row counts, and lazy binary retrieval through a downstream extraction step when binary retrieval is part of the feature.
+
+### REST API behavior
+
+Run the local API and send real HTTP requests to the route. Verify status, response schema, persisted state, authentication behavior, and transaction identifiers as applicable. Do not substitute an in-process test client unless the user asks for automated API tests.
+
+### Python library behavior
+
+Create a small runner that calls `DocpipeFlowManager` with the scenario flow and verifies its returned result plus persisted artifacts. Keep runner logic outside `src/`.
+
+When choosing a scenario, read [references/scenarios.md](references/scenarios.md) and start from the closest maintained sample. Reduce it to the behavior under test instead of copying a full pipeline unchanged.
+
+## Workflow
+
+### 1. Define the acceptance contract
+
+Write a short Given/When/Then scenario and turn it into explicit checks. Include:
+
+- expected job and node status;
+- expected input and output row counts;
+- required output columns and important values;
+- expected failed and skipped document counts;
+- expected external record, index, file, or API state;
+- any behavior that must not occur.
+
+Separate feature assertions from integrity assertions. For example, verifying that a new enrichment column contains the expected value is a feature assertion; verifying that no input document disappeared is an integrity assertion.
+
+### 2. Prepare isolated artifacts
+
+Create a temporary directory with `mktemp -d` and place the scenario flow, generated input, runner, and feature-specific verifier there. Use paths that resolve correctly when commands run from the repository root.
+
+Prefer an existing small fixture from `tests/fixtures/` when it expresses the scenario. Generate a new temporary input when precise content is needed. Never alter shared fixtures for an ad hoc run.
+
+### 3. Build the runner
+
+For a CLI flow, start from the closest current sample and reduce it. A typical local root is:
+
+```json
+{
+  "flow_name": "temporary-feature-validation",
+  "global_config": {
+    "doc_column": "content",
+    "disable_validation": false,
+    "force_ingest": true,
+    "enable_micro_batching": false,
+    "data_storage_type": "local"
+  },
+  "flow": [
+    {
+      "type": "ingest_source",
+      "name": "ingest",
+      "config": {
+        "provider": "filesystem",
+        "connection_params": {
+          "paths": ["tests/fixtures/customer_support_docs"]
+        },
+        "include_filter": "txt",
+        "max_files": 3
+      }
+    }
+  ]
+}
+```
+
+Change the flow name for each independent scenario when incremental metadata could affect results. Set `enable_micro_batching` explicitly: false for a deterministic baseline, true only when micro-batching is itself being tested or a second parity run is required.
+
+When testing a custom operator, set `DOCPIPE_CUSTOM_OPERATORS` for validation and execution and verify that `docling-pipelines --list-operators --verbose` shows its `short_name`.
+
+### 4. Preflight and validate
+
+Activate the project environment first:
+
+```bash
+source .venv/bin/activate
+docling-pipelines --flow-file /path/to/temporary-flow.json --validate
+```
+
+Resolve validation failures before execution. Preflight only the external dependencies used by the scenario. If a required service is unavailable:
+
+- run a smaller local slice only if it still proves a distinct acceptance criterion;
+- mark the external criterion `BLOCKED`, not `PASS`;
+- report the exact prerequisite and rerun command.
+
+The user's request to run feature validation authorizes ordinary local execution and temporary files. Ask before testing against a shared or production-like external system, creating costly resources, or performing destructive cleanup.
+
+### 5. Execute through the public surface
+
+Run from the repository root and capture combined output in the temporary bundle:
+
+```bash
+source .venv/bin/activate
+docling-pipelines --flow-file /path/to/temporary-flow.json
+```
+
+Record the flow path, start time, command, exit code, `job_id`, and `job_run_id`. Stop retrying after one repeat with the same failure unless a concrete environmental correction was made.
+
+### 6. Verify independently of test cases
+
+Run the bundled baseline verifier against the generated run artifacts:
+
+```bash
+source .venv/bin/activate
+python .skills/feature-testing-workflow/scripts/verify_flow_run.py \
+  --started-after 2026-08-31T10:00:00+00:00 \
+  --expect-node ingest \
+  --min-rows ingest:1
+```
+
+Add feature-specific checks in a temporary `verify.py` or direct service query. Use explicit failures and a nonzero exit code; do not import pytest. Verify the actual values described in the acceptance contract, not only the presence of files or columns.
+
+Useful evidence sources include:
+
+- `data/{job_id}/{job_run_id}/docpipe_logs/job_stats.json`;
+- `data/{job_id}/{job_run_id}/data/{node_name}_*/output.parquet`;
+- `job_report_{job_run_id}.csv` when report generation is relevant;
+- API response bodies and persisted DTO-visible state;
+- isolated OpenSearch/Milvus records for vector database behavior;
+- destination files or objects for storage-output behavior.
+
+For micro-batching, verify both the combined output and parity with the non-batched baseline: row count, schema, document identifiers, failure/skip accounting, and feature values must agree unless the feature intentionally changes them.
+
+### 7. Report the result
+
+Report each acceptance criterion as `PASS`, `FAIL`, or `BLOCKED`, followed by the evidence that supports it. Include:
+
+- exact commands needed to reproduce the run;
+- temporary flow and input paths;
+- job identifiers and inspected artifact paths;
+- relevant row counts, columns, values, and service queries;
+- failures with the earliest meaningful error and likely layer;
+- environmental limitations and unverified criteria;
+- whether temporary artifacts or isolated external resources remain.
+
+Do not claim the feature is validated when only configuration validation passed, when required external checks were skipped, or when the verifier did not exercise the requested behavior.
+
+## Optional relationship to automated tests
+
+Existing tests may help discover realistic inputs or expected behavior, but this workflow must remain runnable when no tests exist. After a successful feature run, recommend durable regression tests only as a separate follow-up. Do not make their creation or execution part of the feature-validation result unless the user asks.

--- a/.skills/feature-testing-workflow/references/scenarios.md
+++ b/.skills/feature-testing-workflow/references/scenarios.md
@@ -1,0 +1,100 @@
+# Feature Validation Scenarios
+
+Start from one maintained scenario, reduce it to the feature boundary, and write acceptance checks before execution. These examples are runtime references, not prerequisites for pytest coverage.
+
+## Local operator scenario
+
+Use for ingest, extraction, or a deterministic operator without external services.
+
+- Starting flow: `sample_flows/quickstart/basic_ingest_extract.json`
+- Small fixtures: `tests/fixtures/customer_support_docs/` or `tests/fixtures/invoices/invoice.md`
+- Persist outputs with `data_storage_type: "local"`.
+- Remove extraction when the feature consumes ingest metadata directly.
+
+Example acceptance checks:
+
+- job status is `Completed` or an explicitly accepted warning status;
+- ingest and target-node document counts agree;
+- target output contains the new column;
+- the column has the expected value for a known input;
+- failed document count is zero.
+
+## Quality or enrichment operator
+
+- PII/HAP: `sample_flows/operators/pii_hap_detection.json`
+- Classification: `sample_flows/operators/classification_ollama.json`
+- Entity curation: `sample_flows/operators/entity_curation_ollama.json`
+- Multi-stage local behavior: `sample_flows/advanced/multi_stage_enrichment.json`
+
+Use a fixture with deliberately known content. Assert exact annotations, labels, or scores where deterministic; for probabilistic LLM output, assert the documented structural and threshold invariants rather than a brittle full string.
+
+## Branch and merge behavior
+
+- Branching baseline: `sample_flows/advanced/branching_quality_routing.json`
+- Multi-branch merge: `sample_flows/advanced/quality_branching_merge_pipeline.json`
+- Dual embeddings: `sample_flows/advanced/branching_dual_embeddings.json`
+
+Verify each input identifier lands in exactly the intended branch, no branch receives an unexpected identifier, and the merged identifier multiset matches the contract.
+
+## Micro-batching parity
+
+- Hybrid chunking: `sample_flows/advanced/hybrid_chunking.json`
+- OpenSearch micro-batching: `sample_flows/vectordb/opensearch_integration.json`
+- Unit-level orchestration references: `tests/unit/core/orchestrator/test_batch_manager.py` and `test_terminal_path_batch_propagation.py`
+
+Run once with `enable_micro_batching: false` and once with it true. Compare row counts, schemas, document identifiers, feature values, and failed/skipped accounting. Timing differences are not parity failures.
+
+## Ingest provider scenario
+
+- Filesystem: `sample_flows/quickstart/basic_ingest_extract.json`
+- S3: `sample_flows/use_cases/s3_to_opensearch.json`
+- Provider implementation map: `.skills/docpipe-ingest-source-adapter/references/reference-implementations.md`
+
+Verify filtering and metadata at the ingest node. Add extraction only to prove binary retrieval. For remote providers, use a dedicated folder or prefix containing a small known corpus.
+
+## Vector database scenario
+
+- OpenSearch: `sample_flows/vectordb/opensearch_integration.json`
+- Milvus: `sample_flows/vectordb/milvus_integration.json`
+- Full local-to-vector flow: `sample_flows/quickstart/complete_pipeline_ollama.json`
+
+Use a unique temporary index or collection. Verify stored document count, identifier, vector dimension, mapped metadata, and one retrieval/query behavior when it is part of the feature. Do not mark the scenario passed from the pipeline exit code alone.
+
+## Storage-output scenario
+
+- Processed content to S3: `sample_flows/storage_output/processed_content_s3.json`
+- Refetch original to filesystem: `sample_flows/storage_output/refetch_original_filesystem.json`
+- Google Drive, SharePoint, and Box examples: other files in `sample_flows/storage_output/`
+
+Verify destination paths or keys, bytes or serialized content, overwrite mode, per-document result metadata, and the absence of writes outside the isolated test prefix.
+
+## API scenario
+
+- Route implementations: `src/docpipe/api/routes/`
+- DTOs and mappers: `src/docpipe/api/dto/`
+- Existing request shapes: `tests/integration/api/`
+- OpenAPI contract: `tests/unit/api/test_openapi.py`
+
+Use the existing integration tests only to discover request payloads and dependency requirements. Send real HTTP requests to the running local API for feature validation, then verify both response DTOs and persisted externally visible state.
+
+## Baseline verifier examples
+
+Check one node and a produced column:
+
+```bash
+python .skills/feature-testing-workflow/scripts/verify_flow_run.py \
+  --run-dir data/<job_id>/<job_run_id> \
+  --expect-node enrich \
+  --expect-column enrich:quality_score \
+  --min-rows enrich:1
+```
+
+Check an exact job input count:
+
+```bash
+python .skills/feature-testing-workflow/scripts/verify_flow_run.py \
+  --run-dir data/<job_id>/<job_run_id> \
+  --expected-total 3
+```
+
+The baseline verifier proves only generic artifact invariants. Add a temporary feature-specific verifier or direct service query for exact values and side effects.

--- a/.skills/feature-testing-workflow/scripts/verify_flow_run.py
+++ b/.skills/feature-testing-workflow/scripts/verify_flow_run.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Verify persisted docpipe flow artifacts without using a test framework."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-root", type=Path, default=Path("data"))
+    parser.add_argument("--run-dir", type=Path, help="Explicit data/{job_id}/{job_run_id} directory")
+    parser.add_argument(
+        "--started-after",
+        type=datetime.fromisoformat,
+        help="Only consider job_stats.json files modified after this ISO-8601 timestamp",
+    )
+    parser.add_argument(
+        "--expect-status",
+        action="append",
+        dest="expected_statuses",
+        help="Allowed job status; repeat for multiple values",
+    )
+    parser.add_argument("--expected-total", type=int, help="Expected job-level total_docs count")
+    parser.add_argument("--expect-node", action="append", default=[], help="Expected node name")
+    parser.add_argument(
+        "--expect-column",
+        action="append",
+        default=[],
+        metavar="NODE:COLUMN",
+        help="Require a column in every persisted output for a node",
+    )
+    parser.add_argument(
+        "--min-rows",
+        action="append",
+        default=[],
+        metavar="NODE:COUNT",
+        help="Require at least COUNT persisted rows for a node",
+    )
+    parser.add_argument("--allow-failures", action="store_true", help="Do not fail on job-level failed_docs")
+    return parser.parse_args()
+
+
+def count_value(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value)
+    raise ValueError(f"Cannot interpret count from {value!r}")
+
+
+def find_run_dir(*, data_root: Path, started_after: datetime | None) -> Path:
+    candidates = list(data_root.glob("*/*/docpipe_logs/job_stats.json"))
+    if started_after is not None:
+        threshold = started_after.timestamp()
+        candidates = [path for path in candidates if path.stat().st_mtime >= threshold]
+    if not candidates:
+        raise FileNotFoundError(f"No matching job_stats.json found under {data_root}")
+    return max(candidates, key=lambda path: path.stat().st_mtime).parent.parent
+
+
+def load_stats(*, run_dir: Path) -> dict[str, Any]:
+    stats_path = run_dir / "docpipe_logs" / "job_stats.json"
+    if not stats_path.is_file():
+        raise FileNotFoundError(f"Job statistics not found: {stats_path}")
+    with stats_path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def parse_pair(*, raw: str, value_name: str) -> tuple[str, str]:
+    if ":" not in raw:
+        raise ValueError(f"Expected NODE:{value_name}, received {raw!r}")
+    node, value = raw.split(":", 1)
+    if not node or not value:
+        raise ValueError(f"Expected NODE:{value_name}, received {raw!r}")
+    return node, value
+
+
+def find_node_stats(*, stats: dict[str, Any], node_name: str) -> dict[str, Any] | None:
+    node_stats = stats.get("node_stats", {})
+    if not isinstance(node_stats, dict):
+        return None
+    return next(
+        (node for node in node_stats.values() if isinstance(node, dict) and node.get("name") == node_name), None
+    )
+
+
+def node_outputs(*, run_dir: Path, node_name: str) -> list[Path]:
+    return sorted((run_dir / "data").glob(f"{node_name}_*/output.parquet"))
+
+
+def main() -> int:
+    args = parse_args()
+    errors: list[str] = []
+
+    try:
+        run_dir = args.run_dir or find_run_dir(data_root=args.data_root, started_after=args.started_after)
+        stats = load_stats(run_dir=run_dir)
+    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    expected_statuses = set(args.expected_statuses or ["Completed", "CompletedWithWarnings"])
+    actual_status = stats.get("status") or stats.get("job_status")
+    if actual_status not in expected_statuses:
+        errors.append(f"job status {actual_status!r} is not one of {sorted(expected_statuses)!r}")
+
+    try:
+        failed_count = count_value(stats.get("failed_docs"))
+        total_count = count_value(stats.get("total_docs"))
+    except ValueError as exc:
+        errors.append(str(exc))
+        failed_count = -1
+        total_count = -1
+
+    if not args.allow_failures and failed_count > 0:
+        errors.append(f"job contains {failed_count} failed document(s)")
+    if args.expected_total is not None and total_count != args.expected_total:
+        errors.append(f"total_docs is {total_count}, expected {args.expected_total}")
+
+    for node_name in args.expect_node:
+        if find_node_stats(stats=stats, node_name=node_name) is None:
+            errors.append(f"node {node_name!r} is absent from job statistics")
+
+    output_cache: dict[str, list[tuple[Path, Any]]] = {}
+
+    def read_outputs(node_name: str) -> list[tuple[Path, Any]]:
+        if node_name not in output_cache:
+            paths = node_outputs(run_dir=run_dir, node_name=node_name)
+            output_cache[node_name] = [(path, pq.read_table(path)) for path in paths]
+        return output_cache[node_name]
+
+    try:
+        for raw in args.expect_column:
+            node_name, column = parse_pair(raw=raw, value_name="COLUMN")
+            outputs = read_outputs(node_name)
+            if not outputs:
+                errors.append(f"node {node_name!r} has no persisted output.parquet")
+                continue
+            missing = [str(path) for path, table in outputs if column not in table.column_names]
+            if missing:
+                errors.append(f"column {column!r} is missing from: {', '.join(missing)}")
+
+        for raw in args.min_rows:
+            node_name, minimum_text = parse_pair(raw=raw, value_name="COUNT")
+            minimum = int(minimum_text)
+            outputs = read_outputs(node_name)
+            if not outputs:
+                errors.append(f"node {node_name!r} has no persisted output.parquet")
+                continue
+            rows = sum(table.num_rows for _, table in outputs)
+            if rows < minimum:
+                errors.append(f"node {node_name!r} has {rows} persisted row(s), expected at least {minimum}")
+    except (OSError, ValueError) as exc:
+        errors.append(str(exc))
+
+    print(f"Run directory: {run_dir}")
+    print(f"Job status: {actual_status}")
+    print(f"Total documents: {total_count}")
+    print(f"Failed documents: {failed_count}")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print("PASS: baseline flow-run checks succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Issue
- N/A

## Dev Tracking
N/A

## Description
Adds four agent skills under `.skills/` for developer workflows and a `CLAUDE.md` file that imports `AGENTS.md` for Claude Code compatibility.

**Skills added:**
- `.skills/docpipe-custom-operator/` — guidance for building externally-loaded custom operators
- `.skills/docpipe-ingest-source-adapter/` — guidance for adding new ingest source providers
- `.skills/docpipe-operator-development/` — guidance for built-in operator development
- `.skills/feature-testing-workflow/` — runtime feature validation without pytest

**`CLAUDE.md`:** single `@AGENTS.md` directive, matching the pattern used by [docling upstream](https://github.com/docling-project/docling/blob/main/CLAUDE.md).

## Basic Checklist
- [ ] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality — N/A (docs/skills only)
- [x] Documentation updated (see Documentation Update Checklist below)
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
None

## Testing Details
No code changes — skills are markdown guidance files and a Python verifier script. Pre-commit hooks all passed.

## Documentation Update Checklist
- [x] N/A - No documentation updates needed

### Pre-Commit Hook Results
```
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
mixed line ending........................................................Passed
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
Detect secrets...........................................................Passed
```