### PR TITLE
fix: replace open() with Path.open() for PTH123 compliance

### DIFF
--- a/src/docpipe/core/assets/flows/adapters/config/repository_factory.py
+++ b/src/docpipe/core/assets/flows/adapters/config/repository_factory.py
@@ -62,7 +62,7 @@ class RepositoryFactory:
             return {}
 
         try:
-            with open(config_path) as file:
+            with config_path.open() as file:
                 yaml_config = yaml.safe_load(file)
         except yaml.YAMLError as exc:
             logger.warning(f"Invalid repository YAML configuration at {config_path}: {exc}")

--- a/src/docpipe/storage/file_system/key_value_storage.py
+++ b/src/docpipe/storage/file_system/key_value_storage.py
@@ -117,7 +117,7 @@ class FileSystemStorage(KeyValueStorage):
             temp_path = record_path.with_suffix(".tmp")
 
             # Atomic write: write to temp file, then rename
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with temp_path.open("w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, default=str)
 
             temp_path.replace(record_path)
@@ -140,7 +140,7 @@ class FileSystemStorage(KeyValueStorage):
             if not record_path.exists():
                 return None
 
-            with open(record_path, encoding="utf-8") as f:
+            with record_path.open(encoding="utf-8") as f:
                 data = json.load(f)
 
             logger.debug(f"Retrieved record: {collection}/{key}")
@@ -168,7 +168,7 @@ class FileSystemStorage(KeyValueStorage):
             records = []
             for record_file in collection_dir.glob("*.json"):
                 try:
-                    with open(record_file, encoding="utf-8") as f:
+                    with record_file.open(encoding="utf-8") as f:
                         data = json.load(f)
                     records.append(data)
                 except Exception as e:

--- a/tests/unit/core/assets_management/adapters/config/test_repository_factory.py
+++ b/tests/unit/core/assets_management/adapters/config/test_repository_factory.py
@@ -109,6 +109,16 @@ class TestRepositoryFactory:
         assert isinstance(repository, LocalFlowRepository)
         assert repository.flows_dir == custom_dir.resolve()
 
+    def test_load_yaml_config_falls_back_on_invalid_yaml(self, tmp_path, monkeypatch):
+        """Test that a malformed docpipe.yaml is swallowed and an empty config is returned."""
+        config_path = tmp_path / "docpipe.yaml"
+        config_path.write_text("assets_management: [unterminated", encoding="utf-8")
+
+        monkeypatch.setenv(ENV_CONFIG_PATH_KEY, str(config_path))
+
+        # Should not raise despite the invalid YAML; falls back to an empty config.
+        assert RepositoryFactory._load_yaml_config() == {}
+
     def test_create_flow_repository_env_base_dir_overrides_yaml(self, tmp_path, monkeypatch):
         """Test that LOCAL_FLOWS_DIR overrides docpipe.yaml base_dir."""
         yaml_dir = tmp_path / "yaml_flows"


### PR DESCRIPTION
Fixes #21

## Summary
- Replaced the remaining raw `open()` calls in `src/docpipe/storage/file_system/key_value_storage.py` (lines 120, 143, 171) with `Path.open()`.
- Also found and fixed one additional PTH123 violation not listed in the issue, in `src/docpipe/core/assets/flows/adapters/config/repository_factory.py` (line 65), via a repo-wide `ruff check --select PTH123 src/` sweep.
- `local_flow_repository.py:178` and all 4 lines in `local_asset_repository.py` already used `Path.open()`/`Path(...).open()` at the time of this fix, so no change was needed there.
- Added a test (`test_load_yaml_config_falls_back_on_invalid_yaml`) covering the `yaml.YAMLError` fallback branch in `RepositoryFactory._load_yaml_config`, which previously had no error-path coverage touching the changed `open()` call.

## Verification
- `ruff check --select PTH123 src/` passes repo-wide.
- Full `ruff check` passes on all touched files.
- `encoding=` arguments and the atomic write-then-rename semantics (`temp_path.replace(record_path)`) are preserved unchanged — only the call site changed from `open(x, ...)` to `x.open(...)`.
- Existing tests for the affected modules pass (`test_repository_factory.py`, `test_file_system_storage.py`, `test_local_asset_repository_integration.py`, `test_local_flow_repository.py`).

## Note
The `FileSystemStorage` class in `key_value_storage.py` appears to be unused/dead code (not instantiated anywhere in `src/` or `tests/`) — it's superseded by `KeyValueFileSystemStorage` in `key_value_file_system_storage.py`, which was already PTH123-compliant. Fixed it anyway per the issue's file list, but flagging in case the class should be removed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)