### PR TITLE
docs: remove stale src/docpipe_app/backend references from contributor guides (#19)

### DIFF
--- a/docs/guides/CREATE_CONNECTOR_GUIDE.md
+++ b/docs/guides/CREATE_CONNECTOR_GUIDE.md
@@ -769,14 +769,14 @@ Study these existing connectors for best practices:
 
 ### 1. Execute Flow
 ```bash
-source src/docpipe_app/backend/.venv/bin/activate
+source .venv/bin/activate
 export PYTHONPATH="$(pwd)/src:${PYTHONPATH}"
 docling-pipelines --flow-file tests/flow_your_connector.json
 ```
 
 ### 2. Run Tests
 ```bash
-source src/docpipe_app/backend/.venv/bin/activate
+source .venv/bin/activate
 export PYTHONPATH="$(pwd)/src:${PYTHONPATH}"
 uv run pytest tests/unit/operators/ingest/test_your_connector.py -v
 ```

--- a/docs/internals/DOCUMENT_LIBRARIES_ARCHITECTURE.md
+++ b/docs/internals/DOCUMENT_LIBRARIES_ARCHITECTURE.md
@@ -246,20 +246,19 @@ tests/unit/core/assets_management/document_libraries/
 ### Running Tests
 
 ```bash
-# Navigate to backend directory
-cd src/docpipe_app/backend
+# Run from the project root
 
 # Set PYTHONPATH
-export PYTHONPATH="$(cd ../../.. && pwd)/src/docpipe_app/backend:${PYTHONPATH}"
+export PYTHONPATH="$(pwd)/src:${PYTHONPATH}"
 
 # Run all document library tests
-uv run pytest ../../../tests/unit/core/assets_management/document_libraries/ -v
+uv run pytest tests/unit/core/assets_management/document_libraries/ -v
 
 # Run specific test file
-uv run pytest ../../../tests/unit/core/assets_management/document_libraries/domain/models/test_document_library_validation.py -v
+uv run pytest tests/unit/core/assets_management/document_libraries/domain/models/test_document_library_validation.py -v
 
 # Run with coverage
-uv run pytest ../../../tests/unit/core/assets_management/document_libraries/ --cov=core.assets_management.document_libraries --cov-report=html
+uv run pytest tests/unit/core/assets_management/document_libraries/ --cov=core.assets_management.document_libraries --cov-report=html
 ```
 
 ## Usage Examples


### PR DESCRIPTION
Closes #19.

## Summary

Removes all `src/docpipe_app/backend` path references from the contributor documentation. This directory does not exist in the repository — the source package lives at `src/docpipe/`, and the virtual environment is managed at the project root — so contributors following the old instructions would hit `No such file or directory` on the very first step.

## Changes

### `docs/internals/DOCUMENT_LIBRARIES_ARCHITECTURE.md`

**Before (lines 248–262):**
```bash
# Navigate to backend directory
cd src/docpipe_app/backend

# Set PYTHONPATH
export PYTHONPATH="$(cd ../../.. && pwd)/src/docpipe_app/backend:${PYTHONPATH}"

# Run all document library tests
uv run pytest ../../../tests/unit/core/assets_management/document_libraries/ -v
```

**After:**
```bash
# Run from the project root

# Set PYTHONPATH
export PYTHONPATH="$(pwd)/src:${PYTHONPATH}"

# Run all document library tests
uv run pytest tests/unit/core/assets_management/document_libraries/ -v
```

- Removed the `cd src/docpipe_app/backend` step (directory doesn't exist).
- Fixed `PYTHONPATH` to point at `$(pwd)/src` from the project root instead of the non-existent nested path.
- Simplified all `uv run pytest` paths from `../../../tests/...` to `tests/...` (run from project root).

### `docs/guides/CREATE_CONNECTOR_GUIDE.md`

**Before (lines 772, 779):**
```bash
source src/docpipe_app/backend/.venv/bin/activate
```

**After:**
```bash
source .venv/bin/activate
```

Both the *Execute Flow* and *Run Tests* sections are fixed. The `.venv` is created at the project root by `uv sync`, not inside `src/docpipe_app/backend`.

## Verification

`grep -r "docpipe_app" docs/` → **zero matches** after the fix.
