### PR TITLE
fix: docling-pipelines-api console command is not callable (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docling-pipelines-api` console command** — The entry point previously pointed at the FastAPI `app` object (`docpipe.api.main:app`), causing a `TypeError` on invocation. A `run()` launcher function has been added to `src/docpipe/api/main.py` and `pyproject.toml` now registers `docpipe.api.main:run` as the entry point. Running `docling-pipelines-api` now correctly starts a Uvicorn server on `127.0.0.1:8080`.
+
 ### Added
 
 - **Full OCR engine exposure** — Both `docling_library` and `docling_serve` providers now accept an `ocr` block inside `text_extraction.provider_config`. Users can set `ocr.engine` (8 engines: `auto`, `easyocr`, `tesserocr`, `tesseract`, `rapidocr`, `ocrmac`, `kserve_v2_ocr`, `nemotron-ocr`), `ocr.mode` (`default`, `full_page`, `layout_regions`, `pdf_aware_layout_regions`), `ocr.enabled` (bool), and `ocr.engine_options` (pass-through dict). The previously hardcoded `ocr_preset: "auto"` default in `DoclingServeClient` is removed — when no engine is specified, the docling-serve instance uses its own default. Old `do_ocr` / `ocr_engine` / `ocr_languages` fields remain functional but are deprecated in favour of the new `ocr` block.

--- a/docs/api/REST_API_SERVER.md
+++ b/docs/api/REST_API_SERVER.md
@@ -9,12 +9,16 @@ It is suitable for programmatic access, UI integrations, and multi-tenant deploy
 ## Starting the Server
 
 ```bash
-# From the project root (recommended)
-uv run uvicorn docpipe.api.main:app --reload --host 0.0.0.0 --port 8080
+# Recommended — uses the installed console entry point
+source .venv/bin/activate
+docling-pipelines-api
 
-# Or with plain uvicorn after activating the virtual environment
+# Alternative — invoke uvicorn directly
 source .venv/bin/activate
 uvicorn docpipe.api.main:app --reload --host 0.0.0.0 --port 8080
+
+# Or via uv without activating the virtual environment
+uv run uvicorn docpipe.api.main:app --reload --host 0.0.0.0 --port 8080
 ```
 
 Once running, the following URLs are available:

--- a/docs/guides/TELEMETRY_SETUP.md
+++ b/docs/guides/TELEMETRY_SETUP.md
@@ -118,7 +118,7 @@ Run any flow normally - telemetry will be automatically enabled:
 docling-pipelines --flow-file sample_flows/quickstart/basic_ingest_extract.json
 
 # API
-uvicorn docpipe.api.main:app --reload
+docling-pipelines-api
 ```
 
 ### 4. View Traces

--- a/docs/guides/USER_GUIDE_DOCUMENT_LIBRARIES.md
+++ b/docs/guides/USER_GUIDE_DOCUMENT_LIBRARIES.md
@@ -56,13 +56,16 @@ uv sync
 Document Libraries are accessed via REST API endpoints. Start the API server:
 
 ```bash
-# From project root directory (with PYTHONPATH set)
+# Recommended — uses the installed console entry point
+docling-pipelines-api
+
+# Alternative — invoke uvicorn directly (with PYTHONPATH set)
 uvicorn docpipe.api.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 The API will be available at `http://localhost:8000` with interactive documentation at `http://localhost:8000/api/v1/docs`.
 
-**Note:** The command must be run from the project root with `PYTHONPATH` set to include the `src` directory.
+**Note:** The direct `uvicorn` command must be run from the project root with `PYTHONPATH` set to include the `src` directory.
 
 **Troubleshooting:**
 - **Error: "address already in use"**: Port 8000 is already occupied. Either:

--- a/examples/custom_operators/README.md
+++ b/examples/custom_operators/README.md
@@ -153,7 +153,7 @@ docling-pipelines --flow-file custom_flow.json
 export DOCPIPE_CUSTOM_OPERATORS="/path/to/operators/"
 
 # Start API server
-uvicorn docpipe.api.main:app --reload
+docling-pipelines-api
 
 # Submit flow via API
 curl -X POST http://localhost:8000/api/flows/execute \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ Source = "https://github.com/IBM/docling-pipelines"
 "Bug Tracker" = "https://github.com/IBM/docling-pipelines/issues"
 
 [project.scripts]
-docling-pipelines-api = "docpipe.api.main:app"
+docling-pipelines-api = "docpipe.api.main:run"
 docling-pipelines = "docpipe.cli.docpipe_cli:main"
 
 [tool.hatch.build.targets.wheel]

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ anyio==4.14.1
     #   watchfiles
 appdirs==1.4.4
     # via unicategories
-apprise==1.13.0
+apprise==1.13.1
     # via prefect
 asgi-lifespan==2.1.0
     # via prefect
@@ -123,6 +123,7 @@ cloudpathlib==0.25.0
     # via weasel
 cloudpickle==3.1.2
     # via
+    #   joblib
     #   prefect
     #   pydocket
 colorama==0.4.6
@@ -391,7 +392,7 @@ jmespath==1.0.1
     #   botocore
     #   ibm-cos-sdk
     #   ibm-cos-sdk-core
-joblib==1.5.3
+joblib==1.6.0
     # via
     #   nltk
     #   scikit-learn
@@ -879,7 +880,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.7.19
+regex==2026.8.31
     # via
     #   datefinder
     #   dateparser
@@ -1214,7 +1215,7 @@ websockets==16.1.1
     #   uvicorn
 win32-setctime==1.2.0 ; sys_platform == 'win32'
     # via loguru
-wrapt==2.3.0
+wrapt==2.4.0
     # via smart-open
 xlsxwriter==3.2.9
     # via python-pptx

--- a/src/docpipe/api/main.py
+++ b/src/docpipe/api/main.py
@@ -269,10 +269,15 @@ app.add_middleware(PayloadValidationMiddleware)
 app.include_router(api_router)
 
 
-if __name__ == "__main__":
+def run() -> None:
+    """Start the Uvicorn server for the Docpipe API."""
     uvicorn.run(
         "docpipe.api.main:app",
         host="127.0.0.1",
         port=8080,
         reload=True,
     )
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/api/test_app_startup.py
+++ b/tests/unit/api/test_app_startup.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from docpipe.api.auth.dependencies import get_current_user
 from docpipe.api.auth.models import User
-from docpipe.api.main import app
+from docpipe.api.main import app, run
 from docpipe.api.middleware.security_headers import API_CSP, DOCS_CSP
 
 
@@ -23,6 +23,18 @@ def client() -> TestClient:
         username="testuser", email="test@example.com", full_name="Test User"
     )
     return TestClient(app)
+
+
+class TestEntryPoint:
+    """Test the docling-pipelines-api console entry point."""
+
+    def test_run_is_callable(self):
+        """Entry point must be a zero-argument callable, not an object instance."""
+        assert callable(run)
+
+    def test_run_is_not_the_app_object(self):
+        """Entry point must not point directly at the FastAPI app instance."""
+        assert run is not app
 
 
 class TestApplicationStartup:


### PR DESCRIPTION
## Issue
- Fixes #16

## Dev Tracking
N/A

## Description
The `docling-pipelines-api` console entry point was registered against the FastAPI `app`
object (`docpipe.api.main:app`) rather than a callable function, causing a `TypeError` on
invocation. This PR adds a `run()` launcher function and updates the entry point accordingly.

**Changes:**
- `src/docpipe/api/main.py` — Added `def run()` that calls `uvicorn.run(...)`. The existing
  `if __name__ == "__main__"` block now delegates to `run()`.
- `pyproject.toml` — Entry point updated from `docpipe.api.main:app` to `docpipe.api.main:run`.
- `tests/unit/api/test_app_startup.py` — Added `TestEntryPoint` class with two smoke tests
  verifying `run` is callable and is not the `app` object.
- Docs updated in `docs/api/REST_API_SERVER.md`, `docs/guides/USER_GUIDE_DOCUMENT_LIBRARIES.md`,
  `docs/guides/TELEMETRY_SETUP.md`, `examples/custom_operators/README.md` to show
  `docling-pipelines-api` as the recommended start command.
- `CHANGELOG.md` updated under `## [Unreleased]`.

## Basic Checklist
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality
- [x] Documentation updated (see Documentation Update Checklist below)
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
None

## Testing Details
Ran the two new entry-point smoke tests:
```
pytest tests/unit/api/test_app_startup.py::TestEntryPoint -v
```
Both passed. All pre-commit hooks passed.

## Documentation Update Checklist
- [ ] README.md (if adding features, changing structure, or modifying setup)
- [ ] ARCHITECTURE.md (if modifying operators, data flow, or system design)
- [ ] CONTRIBUTING.md (if changing development workflow or code standards)
- [ ] USER_GUIDE_PIPELINE_SETUP.md (if changing installation, setup, or execution)
- [ ] QUICKSTART.md (if changing quick start steps or examples)
- [ ] docs/reference/OPERATORS.md (if adding/modifying operators)
- [ ] TROUBLESHOOTING.md (if discovering new issues or solutions)
- [ ] Operator documentation in docs/operators/ (if operator added/modified)
- [x] N/A - No documentation updates needed for the above; API server startup docs updated
  in `docs/api/REST_API_SERVER.md`, `docs/guides/USER_GUIDE_DOCUMENT_LIBRARIES.md`,
  `docs/guides/TELEMETRY_SETUP.md`, and `examples/custom_operators/README.md`.

### Pre-Commit Hook Results
```
uv-export................................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check toml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
mixed line ending........................................................Passed
nbstripout...........................................(no files to check)Skipped
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
bandit...................................................................Passed
mypy.....................................................................Passed
interrogate..............................................................Passed
Detect secrets...........................................................Passed
```

### Note
 1. **Keyword Arguments** - Ensure function arguments are keyword-based, not positional - [Link](https://docs.python.org/3/glossary.html#term-argument)
 2. **Metadata Independence:** When adding or modifying operator metadata, ensure the data does not depend on instance variables.
 3. **Method Requirements:** Ensure `get_metadata` is a static method. If `get_required_features` depends on instance variables, the operator must implement `get_static_required_features` using the default values referenced in `get_required_features`
 4. For every PR, ensure that the pre-commit hook output has been included.