### PR TITLE
Fix dry-run prerequisite probing in example tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Versioning follows [Semantic Versioning 2.0.0](https://semver.org/).
 - **GPU acceleration for `ExtractOperator`** — `docling_library` provider now supports GPU device selection via `standard_pipeline.accelerator` in `provider_config`. Accepted devices: `mps` (Apple Silicon), `cuda`, `cuda:<index>` (NVIDIA), `xpu` (Intel). When `device` is omitted from the accelerator block, the best available GPU is auto-detected at runtime via torch (CUDA → MPS → XPU). Validates device availability via torch backends before loading any model. Requires `max_workers: 1` and `use_processes: false`. One `DocumentConverter` is constructed per adapter execution and reused across all documents. Flows without accelerator config are unaffected.
 - Flow execution now defaults `enable_micro_batching` to `true` for CLI, REST job runs, and `DocpipeFlowManager` when the flow does not set it explicitly. A user-provided `global_config.enable_micro_batching` value still overrides the default.
 
+### Fixed
+
+- `scripts/test_examples.py --dry-run` now skips examples before probing Ollama, OpenSearch, environment variables, or example files.
+
 ---
 
 ## [0.1.0] - 2025-07-15

--- a/scripts/test_examples.py
+++ b/scripts/test_examples.py
@@ -296,6 +296,15 @@ class ExampleTester:
 
         start_time = time.time()
 
+        if self.dry_run:
+            return TestResult(
+                name=test.name,
+                status=TestStatus.SKIPPED,
+                duration=0,
+                output="",
+                skip_reason="Dry run mode",
+            )
+
         # Check prerequisites
         can_run, skip_reason = self.check_prerequisites(test=test)
         if not can_run:
@@ -305,15 +314,6 @@ class ExampleTester:
                 duration=0,
                 output="",
                 skip_reason=skip_reason,
-            )
-
-        if self.dry_run:
-            return TestResult(
-                name=test.name,
-                status=TestStatus.SKIPPED,
-                duration=0,
-                output="",
-                skip_reason="Dry run mode",
             )
 
         # Run the test

--- a/tests/unit/scripts/__init__.py
+++ b/tests/unit/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for repository scripts."""

--- a/tests/unit/scripts/test_test_examples.py
+++ b/tests/unit/scripts/test_test_examples.py
@@ -1,0 +1,55 @@
+"""Tests for the example test runner."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.test_examples import ExampleTest, ExampleTester
+from scripts.test_examples import TestCategory as ExampleCategory
+from scripts.test_examples import TestStatus as ExampleStatus
+
+
+def test_dry_run_skips_before_checking_prerequisites(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Dry-run mode must not probe external services or local prerequisites."""
+    tester = ExampleTester(dry_run=True)
+    test = ExampleTest(
+        name="Offline dry run",
+        path=tmp_path / "missing.py",
+        category=ExampleCategory.OPERATORS,
+        requires_ollama=True,
+        requires_opensearch=True,
+        requires_env=["MISSING_API_KEY"],
+    )
+
+    def fail_if_called(*, test: ExampleTest) -> tuple[bool, str | None]:
+        pytest.fail(f"check_prerequisites() unexpectedly called for {test.name}")
+
+    monkeypatch.setattr(tester, "check_prerequisites", fail_if_called)
+
+    result = tester.run_test(test=test)
+
+    assert result.status is ExampleStatus.SKIPPED
+    assert result.skip_reason == "Dry run mode"
+
+
+def test_normal_run_checks_prerequisites(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Non-dry runs must retain prerequisite checks."""
+    tester = ExampleTester()
+    test = ExampleTest(
+        name="Normal run",
+        path=tmp_path / "missing.py",
+        category=ExampleCategory.OPERATORS,
+    )
+    checked_tests: list[ExampleTest] = []
+
+    def check_prerequisites(*, test: ExampleTest) -> tuple[bool, str | None]:
+        checked_tests.append(test)
+        return False, "Prerequisite unavailable"
+
+    monkeypatch.setattr(tester, "check_prerequisites", check_prerequisites)
+
+    result = tester.run_test(test=test)
+
+    assert checked_tests == [test]
+    assert result.status is ExampleStatus.SKIPPED
+    assert result.skip_reason == "Prerequisite unavailable"


### PR DESCRIPTION
## Summary

Fixes dry-run handling in `scripts/test_examples.py` so listing example tests remains offline and side-effect free.

Before this change, `ExampleTester.run_test()` called `check_prerequisites()` before checking `self.dry_run`. As a result, `--dry-run` could probe Ollama and OpenSearch, inspect environment variables, and check example file paths before reporting that the test was skipped. This made dry runs depend on local services and could report prerequisite failures instead of the intended `Dry run mode` reason.

The dry-run guard now returns before prerequisite checks. Requirement metadata is still displayed by `run_tests()`, while normal executions continue to validate prerequisites before launching an example.

## Changes

- return `SKIPPED` with `Dry run mode` before calling `check_prerequisites()`;
- add a regression test that fails if prerequisite checks run during a dry run;
- add a control test confirming normal runs still check prerequisites;
- document the fix under the changelog's Unreleased section.

## Validation

- `.venv/bin/python -m pytest tests/unit/scripts/test_test_examples.py -q` — 2 passed;
- `ruff check scripts/test_examples.py tests/unit/scripts/test_test_examples.py` — passed;
- `ruff format --check scripts/test_examples.py tests/unit/scripts/test_test_examples.py` — passed;
- `python scripts/test_examples.py --dry-run` — all 20 examples reported `Dry run mode`, while their requirement metadata remained visible;
- `git diff --check` — passed.

Closes #18
