### PR TITLE
feat(ingest): add Dropbox source adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning follows [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Added
 
+- **Dropbox ingest source adapter** — new `dropbox` provider for `IngestSourceOperator`, built on the official Dropbox Python SDK. Supports access-token and refresh-token (long-lived) OAuth2 authentication, cursor-based pagination, recursive or single-level folder traversal, single-file ingestion by path or file id, extension / size / glob-exclusion filters, `max_files` limits, and lazy binary retrieval by Dropbox file id. Adds the `dropbox==12.2.1` dependency. See [the adapter README](src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/README.md).
+
 - **Full OCR engine exposure** — Both `docling_library` and `docling_serve` providers now accept an `ocr` block inside `text_extraction.provider_config`. Users can set `ocr.engine` (8 engines: `auto`, `easyocr`, `tesserocr`, `tesseract`, `rapidocr`, `ocrmac`, `kserve_v2_ocr`, `nemotron-ocr`), `ocr.mode` (`default`, `full_page`, `layout_regions`, `pdf_aware_layout_regions`), `ocr.enabled` (bool), and `ocr.engine_options` (pass-through dict). The previously hardcoded `ocr_preset: "auto"` default in `DoclingServeClient` is removed — when no engine is specified, the docling-serve instance uses its own default. Old `do_ocr` / `ocr_engine` / `ocr_languages` fields remain functional but are deprecated in favour of the new `ocr` block.
 
 - **docling-pipelines-slim** — New lightweight package variant that excludes certain operator dependencies. Use when your codebase doesn't require specific built-in operators. See [docs/guides/SLIM_VARIANT.md](docs/guides/SLIM_VARIANT.md) for installation and usage details.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It connects to cloud document sources (S3, OneDrive, SharePoint, Google Drive, B
 
 ## Features
 
-- 📥 **Multi-source ingestion** — local filesystem, Amazon S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, and web pages
+- 📥 **Multi-source ingestion** — local filesystem, Amazon S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, Dropbox, and web pages
 - 📄 **Document extraction** — PDF, DOCX, HTML, images, and more via Docling, with optional VLM and ASR pipelines
 - 🧠 **Entity extraction** — LLM-based extraction via LiteLLM (100+ providers), IBM watsonx.ai, or Docling templates
 - ✂️ **Chunking** — Docling-native and semantic chunking strategies
@@ -87,7 +87,7 @@ Check out the full [documentation](docs/README.md) for installation, flow author
 
 | Category | Operators |
 |---|---|
-| **Ingest** | Local Filesystem & Remote Source Ingest (`ingest_source`) — [filesystem, S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, web](docs/operators/ingest/ingest_source_readme.md) |
+| **Ingest** | Local Filesystem & Remote Source Ingest (`ingest_source`) — [filesystem, S3, IBM COS, SharePoint, OneDrive, Google Drive, Box, Dropbox, web](docs/operators/ingest/ingest_source_readme.md) |
 | **Extract** | Document Extractor (`extract_operator`), ACL Extraction (`acl_operator`) |
 | **Functional** | Chunking (`chunker`), Embeddings (`embeddings`), Branching Operator (`branching`), Merge Operator (`merge`), Document ID Hash (`doc_id_hash`), Entity Curation (`entity_curation`), No-op (`noop`) |
 | **Quality** | Language Annotator (`lang_detect`), Readability Operator (`readability`), PII and HAP Annotator (`pii_and_hap`), Document Classifier (`document_classifier`), Annotation Filter (`sql_filter`), Redaction (`redaction`), De-duplicator (`ededup`), ML Text Enrichment (`ml_enrichment`), Document Quality (`doc_quality`) |

--- a/docs/guides/CREATE_CONNECTOR_GUIDE.md
+++ b/docs/guides/CREATE_CONNECTOR_GUIDE.md
@@ -483,6 +483,8 @@ Create a JSON flow file (e.g., `sample_flows/use_cases/your_connector_pipeline.j
 
 Here's a complete example implementing a Dropbox connector:
 
+> **Note:** A production Dropbox connector now ships with the project. This section remains a simplified teaching example built on raw HTTP calls; the shipped adapter uses the Dropbox SDK, supports refresh-token authentication and paginates listings. See [`sources/dropbox/README.md`](../../src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/README.md) for the real implementation.
+
 ### `dropbox/config.py`
 
 ```python

--- a/docs/operators/ingest/ingest_source_readme.md
+++ b/docs/operators/ingest/ingest_source_readme.md
@@ -1,6 +1,6 @@
 # IngestSourceOperator
 
-Ingests document metadata from cloud storage and collaboration platforms (S3, SharePoint, OneDrive, Google Drive, Box).
+Ingests document metadata from cloud storage and collaboration platforms (S3, SharePoint, OneDrive, Google Drive, Box, Dropbox).
 
 - **Short Name:** `ingest_source`
 - **Category:** Ingest
@@ -265,7 +265,60 @@ The adapter uses JWT (JSON Web Token) authentication which provides:
 - Rotate keys periodically as per security policy
 - Use environment variables for file paths in production
 
-### 7. Custom Loaders
+### 7. Dropbox
+Ingest documents from a Dropbox account using the Dropbox SDK.
+
+**Configuration:**
+```python
+node_config = {
+    'provider': 'dropbox',
+    'connection_params': {
+        'folder_path': '/Reports',  # Optional: folder to ingest from ('' or '/' for account root)
+        'recursive': True,  # Optional: include subfolders (default: True)
+        'max_file_size_mb': 50,  # Optional: max file size in MB
+        'exclude_patterns': ['*.tmp', '*/Archive/*']  # Optional: patterns to exclude
+    },
+    'credentials': {
+        'access_token': '${DROPBOX_ACCESS_TOKEN}'
+    },
+    'include_filter': 'pdf,docx,txt',  # Optional: file extensions to include
+    'max_files': 100  # Optional
+}
+```
+
+**Prerequisites:**
+- Dropbox account and a Dropbox app created in the [App Console](https://www.dropbox.com/developers/apps)
+- App scopes: `account_info.read`, `files.metadata.read`, `files.content.read`
+- An access token, or a refresh token with the app key and secret
+- Dependencies: `pip install dropbox`
+
+**Parameters:**
+- `folder_path` (optional): Dropbox folder to ingest from; empty string or `/` means the account root
+- `file_path` (optional): Ingest a single file by path (`/Reports/q1.pdf`) or file id (`id:abc123`); ignores folder settings and filters
+- `recursive` (optional): Boolean, include subfolders (default: `True`)
+- `max_file_size_mb` (optional): Maximum file size in MB to process
+- `exclude_patterns` (optional): List of glob patterns to exclude (e.g., `['*.tmp', '*/Archive/*']`)
+- `access_token` (credentials): Dropbox OAuth2 access token
+- `refresh_token`, `app_key`, `app_secret` (credentials): Long-lived alternative to `access_token`
+
+**Dropbox App Setup:**
+1. Create a scoped app in the [Dropbox App Console](https://www.dropbox.com/developers/apps)
+2. Choose **App folder** access to limit the app to a single folder, or **Full Dropbox**
+3. On the **Permissions** tab enable `account_info.read`, `files.metadata.read` and `files.content.read`, then submit
+4. Generate an access token on the **Settings** tab, or run the OAuth2 flow with `token_access_type=offline` to obtain a refresh token
+5. Export the token as an environment variable and reference it as `${DROPBOX_ACCESS_TOKEN}` in the flow
+
+**Authentication Notes:**
+- Generated access tokens are short-lived (four hours); use the refresh-token flow for scheduled pipelines
+- Tokens issued before new scopes were saved do not carry those scopes; re-issue the token after changing permissions
+- Apps with **App folder** access see paths relative to their own app folder, not the account root
+
+**Security Notes:**
+- Never commit Dropbox tokens to version control; reference them through environment variables
+- Grant only the scopes listed above; the adapter never writes to Dropbox
+- Rotate tokens periodically and revoke unused app authorizations
+
+### 8. Custom Loaders
 Extend functionality with custom LangChain-compatible loaders.
 
 **Configuration:**
@@ -349,7 +402,7 @@ See the [Usage](#usage) section above and per-provider configuration in [Support
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `provider` | string | **Yes** | — | Source provider: `s3`, `sharepoint`, `onedrive`, `googledrive`, `box` |
+| `provider` | string | **Yes** | — | Source provider: `filesystem`, `s3`, `ibm_cos`, `sharepoint`, `onedrive`, `google_drive`, `box_driver`, `dropbox`, `web` |
 | `connection_params` | object | **Yes** | — | Provider-specific connection settings |
 | `credentials` | object | **Yes** | — | Provider-specific authentication credentials |
 | `include_filter` | string | No | all types | Comma-separated file extensions to include (no dot) |
@@ -650,6 +703,7 @@ botocore==1.42.55
 - **Google Drive:** `google-auth-oauthlib==1.2.4`, `google-auth-httplib2==0.3.0`, `google-api-python-client==2.190.0`, `langchain-google-community==3.0.5`
 - **SharePoint/OneDrive:** `O365==2.1.9`, `langchain-community==0.4.1`
 - **Box:** `box-sdk-gen==1.17.0`, `langchain-community==0.4.1`
+- **Dropbox:** `dropbox==12.2.1`
 - **PDF Processing:** `pypdf2==3.0.1`, `unstructured[pdf]>=0.10.0`
 - **GCP:** `google-cloud-storage==3.9.0`
 - **Azure:** `azure-storage-blob==12.28.0`
@@ -710,7 +764,7 @@ Initialize the operator with configuration.
 
 **Parameters:**
 - `node_config` (dict): Configuration dictionary containing:
-  - `provider` (str): Provider identifier (s3, google_drive, sharepoint, onedrive, box_driver, filesystem, web, custom)
+  - `provider` (str): Provider identifier (s3, google_drive, sharepoint, onedrive, box_driver, dropbox, filesystem, web, custom)
   - `connection_params` (dict): Provider-specific connection parameters
   - `credentials` (dict): Authentication credentials
   - `job_id` (str, optional): Job identifier for tracking
@@ -881,6 +935,24 @@ node_config = {
         'credentials_json_path': os.getenv('BOX_JWT_CONFIG_FILE')
     },
     'include_filter': 'pdf,docx,txt,pptx,xlsx',  # File extensions to include
+    'max_files': 100
+}
+```
+
+### Example 9: Dropbox Folder with Extension Filtering
+```python
+node_config = {
+    'provider': 'dropbox',
+    'connection_params': {
+        'folder_path': '/Reports/2026',
+        'recursive': True,
+        'max_file_size_mb': 50,
+        'exclude_patterns': ['*.tmp', '*/Archive/*']
+    },
+    'credentials': {
+        'access_token': os.getenv('DROPBOX_ACCESS_TOKEN')
+    },
+    'include_filter': 'pdf,docx,txt',
     'max_files': 100
 }
 ```

--- a/docs/reference/OPERATORS.md
+++ b/docs/reference/OPERATORS.md
@@ -156,7 +156,7 @@ For full details on the priority system, override behaviour, and registering cus
 
 #### IngestSourceOperator
 
-**Purpose:** Multi-provider ingest abstraction for sources such as object storage, SharePoint, OneDrive, Google Drive, web pages, and filesystem adapters.
+**Purpose:** Multi-provider ingest abstraction for sources such as object storage, SharePoint, OneDrive, Google Drive, Box, Dropbox, web pages, and filesystem adapters.
 
 **Category:** Ingest
 
@@ -2492,7 +2492,7 @@ For new backends, implement the `DocumentSetStorage` and `DocumentSetMetadataRep
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `provider` | string | Adapter name: `filesystem`, `s3`, `ibm_cos`, `sharepoint`, `onedrive`, or `google_drive` |
+| `provider` | string | Adapter name: `filesystem`, `s3`, `ibm_cos`, `sharepoint`, `dropbox`, `onedrive`, or `google_drive` |
 | `provider_config` | object | Provider-specific connection parameters (see operator README) |
 | `credentials` | object | Provider-specific credentials |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "datatrove==0.3.0",
     "datefinder==1.0.0",
     "docling[rapidocr]==2.121.0",
+    "dropbox==12.2.1",
     "duckdb==1.3.2",
     "fastapi==0.141.1",
     "fasttext-wheel==0.9.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -158,11 +158,11 @@ cryptography==50.0.0
     #   python-jose
 cuda-bindings==13.3.1 ; sys_platform == 'linux'
     # via torch
-cuda-pathfinder==1.8.0 ; sys_platform == 'linux'
+cuda-pathfinder==1.8.1 ; sys_platform == 'linux'
     # via cuda-bindings
 cuda-toolkit==13.0.3.0 ; sys_platform == 'linux'
     # via torch
-cyclopts==4.23.3
+cyclopts==4.24.0
     # via prefect
 cymem==2.0.13
     # via
@@ -179,7 +179,7 @@ datatrove==0.3.0
     # via docling-pipelines
 datefinder==1.0.0
     # via docling-pipelines
-dateparser==1.4.2
+dateparser==1.4.3
     # via prefect
 defusedxml==0.7.1
     # via
@@ -198,19 +198,21 @@ doclang==0.7.3
     # via docling-core
 docling==2.121.0
     # via docling-pipelines
-docling-core==2.92.0
+docling-core==2.94.1
     # via
     #   docling-ibm-models
     #   docling-parse
     #   docling-slim
 docling-ibm-models==3.15.0
     # via docling-slim
-docling-parse==7.16.0
+docling-parse==7.17.0
     # via docling-slim
 docling-slim==2.121.0
     # via docling
 docstring-parser==0.18.0
     # via cyclopts
+dropbox==12.2.1
+    # via docling-pipelines
 duckdb==1.3.2
     # via docling-pipelines
 ecdsa==0.19.2
@@ -260,7 +262,7 @@ google-api-core==2.34.0
     #   google-cloud-storage
 google-api-python-client==2.190.0
     # via docling-pipelines
-google-auth==2.57.0
+google-auth==2.57.1
     # via
     #   google-api-core
     #   google-api-python-client
@@ -286,7 +288,7 @@ google-re2==1.1.20251105
     # via docling-pipelines
 google-resumable-media==2.10.2
     # via google-cloud-storage
-googleapis-common-protos==1.75.2
+googleapis-common-protos==1.75.3
     # via google-api-core
 graphviz==0.21
     # via prefect
@@ -335,7 +337,7 @@ httpx==0.28.1
     #   weasel
 httpx-sse==0.4.3
     # via langchain-community
-huggingface-hub==1.29.0
+huggingface-hub==1.30.0
     # via
     #   accelerate
     #   datatrove
@@ -381,6 +383,7 @@ jinja2==3.1.6
     #   litellm
     #   prefect
     #   spacy
+    #   stone
     #   torch
 jinja2-humanize-extension==0.4.0
     # via prefect
@@ -649,6 +652,7 @@ packaging==26.2
     #   onnxruntime
     #   prefect
     #   spacy
+    #   stone
     #   thinc
     #   transformers
     #   weasel
@@ -774,7 +778,7 @@ pydantic-settings==2.14.2
     #   docling-slim
     #   langchain-community
     #   prefect
-pydocket==0.24.1
+pydocket==0.25.0
     # via prefect
 pygments==2.20.0
     # via
@@ -880,7 +884,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.8.31
+regex==2026.9.3
     # via
     #   datefinder
     #   dateparser
@@ -895,6 +899,7 @@ requests==2.33.0
     #   docker
     #   docling-pipelines
     #   docling-slim
+    #   dropbox
     #   google-api-core
     #   google-cloud-storage
     #   ibm-cos-sdk-core
@@ -1026,6 +1031,8 @@ starlette==1.6.0
     # via
     #   fastapi
     #   prefect
+stone==3.5.4
+    # via dropbox
 strictyaml==1.7.3
     # via pyiceberg
 sympy==1.14.0

--- a/scripts/test_examples.py
+++ b/scripts/test_examples.py
@@ -296,6 +296,15 @@ class ExampleTester:
 
         start_time = time.time()
 
+        if self.dry_run:
+            return TestResult(
+                name=test.name,
+                status=TestStatus.SKIPPED,
+                duration=0,
+                output="",
+                skip_reason="Dry run mode",
+            )
+
         # Check prerequisites
         can_run, skip_reason = self.check_prerequisites(test=test)
         if not can_run:
@@ -305,15 +314,6 @@ class ExampleTester:
                 duration=0,
                 output="",
                 skip_reason=skip_reason,
-            )
-
-        if self.dry_run:
-            return TestResult(
-                name=test.name,
-                status=TestStatus.SKIPPED,
-                duration=0,
-                output="",
-                skip_reason="Dry run mode",
             )
 
         # Run the test

--- a/src/docpipe/core/operators/ingest/adapters/outbound/sources/__init__.py
+++ b/src/docpipe/core/operators/ingest/adapters/outbound/sources/__init__.py
@@ -6,6 +6,7 @@ with the SourceAdapterFactory via the @register_source_adapter decorator.
 
 # Import adapters to trigger registration
 from .box.adapter import BoxSourceAdapter
+from .dropbox.adapter import DropboxSourceAdapter
 from .filesystem.adapter import FilesystemSourceAdapter
 from .google_drive.adapter import GoogleDriveSourceAdapter
 from .onedrive.adapter import OneDriveSourceAdapter
@@ -15,6 +16,7 @@ from .web.adapter import WebPageSourceAdapter
 
 __all__ = [
     "BoxSourceAdapter",
+    "DropboxSourceAdapter",
     "FilesystemSourceAdapter",
     "GoogleDriveSourceAdapter",
     "OneDriveSourceAdapter",

--- a/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/README.md
+++ b/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/README.md
@@ -1,0 +1,196 @@
+# Dropbox Source Adapter
+
+## Overview
+
+The Dropbox source adapter ingests documents from a Dropbox account using the official [Dropbox Python SDK](https://github.com/dropbox/dropbox-sdk-python). Listing is metadata-only and paginated: binary content is downloaded on demand by downstream operators through `fetch_binary_content()`.
+
+The adapter registers with `SourceAdapterFactory` under the provider name `dropbox`.
+
+## Features
+
+- Access-token and refresh-token (long-lived) OAuth2 authentication
+- Cursor-based pagination over `files/list_folder`
+- Recursive or single-level folder traversal
+- Single-file ingestion by path or Dropbox file id
+- File extension, file size, and glob exclusion filters
+- `max_files` limit
+- Lazy binary retrieval by stable Dropbox file id
+- Environment variable resolution for credentials and paths
+
+## Configuration
+
+### Credentials
+
+Provide **either** an access token **or** a refresh token together with the app key and secret.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `access_token` | string | Dropbox OAuth2 access token (short-lived or legacy long-lived token) |
+| `refresh_token` | string | Dropbox OAuth2 refresh token; the SDK refreshes access tokens automatically |
+| `app_key` | string | Dropbox app key, required with `refresh_token` |
+| `app_secret` | string | Dropbox app secret, required with `refresh_token` |
+
+### Connection Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `folder_path` | string | `""` | Folder to ingest from (e.g. `/Reports`). Empty string or `/` means the account root |
+| `file_path` | string | `None` | Ingest a single file by path (`/Reports/q1.pdf`) or file id (`id:abc123`). Ignores folder settings and filters |
+| `recursive` | boolean | `true` | Whether to traverse subfolders |
+| `exclude_patterns` | list[string] | `[]` | Glob patterns excluded by full path or file name (e.g. `["*.tmp", "*/Archive/*"]`) |
+| `max_file_size_mb` | integer | `None` | Maximum file size in MB. `None` means no limit |
+
+File extensions come from the operator-level `include_filter`, and the document limit from the operator-level `max_files`.
+
+## Authentication Setup
+
+### 1. Create a Dropbox App
+
+1. Go to the [Dropbox App Console](https://www.dropbox.com/developers/apps).
+2. Create a new app, choose **Scoped access**, and pick either **App folder** (recommended, limits access to one folder) or **Full Dropbox**.
+3. On the **Permissions** tab enable at least:
+   - `account_info.read` — used by the connection test
+   - `files.metadata.read` — listing files and folders
+   - `files.content.read` — downloading file content
+4. Click **Submit** to save the permissions.
+
+### 2. Obtain a Token
+
+For a quick start, generate a short-lived access token on the app's **Settings** tab (`Generated access token`).
+
+For unattended pipelines, use the refresh-token flow so the SDK renews access tokens automatically:
+
+1. Open the authorization URL in a browser, replacing `<APP_KEY>`:
+   `https://www.dropbox.com/oauth2/authorize?client_id=<APP_KEY>&response_type=code&token_access_type=offline`
+2. Approve access and copy the authorization code.
+3. Exchange the code for a refresh token:
+
+   ```bash
+   curl -X POST https://api.dropboxapi.com/oauth2/token \
+     -u "<APP_KEY>:<APP_SECRET>" \
+     -d code="<AUTH_CODE>" \
+     -d grant_type=authorization_code
+   ```
+
+### 3. Export the Credentials
+
+```bash
+export DROPBOX_ACCESS_TOKEN="<your-access-token>"  # pragma: allowlist secret
+# or, for the refresh-token flow
+export DROPBOX_REFRESH_TOKEN="<your-refresh-token>"  # pragma: allowlist secret
+export DROPBOX_APP_KEY="<your-app-key>"
+export DROPBOX_APP_SECRET="<your-app-secret>"  # pragma: allowlist secret
+```
+
+Reference them from the flow as `${DROPBOX_ACCESS_TOKEN}` — never inline a token in a flow file.
+
+## Usage in Flow
+
+### Access token
+
+```json
+{
+  "type": "ingest_source",
+  "name": "ingest",
+  "config": {
+    "provider": "dropbox",
+    "connection_params": {
+      "folder_path": "/Reports",
+      "recursive": true
+    },
+    "credentials": {
+      "access_token": "${DROPBOX_ACCESS_TOKEN}"
+    },
+    "include_filter": "pdf,docx",
+    "max_files": 100
+  }
+}
+```
+
+### Refresh token with filters
+
+```json
+{
+  "type": "ingest_source",
+  "name": "ingest",
+  "config": {
+    "provider": "dropbox",
+    "connection_params": {
+      "folder_path": "/Reports/2026",
+      "recursive": true,
+      "max_file_size_mb": 50,
+      "exclude_patterns": ["*.tmp", "*/Archive/*"]
+    },
+    "credentials": {
+      "refresh_token": "${DROPBOX_REFRESH_TOKEN}",
+      "app_key": "${DROPBOX_APP_KEY}",
+      "app_secret": "${DROPBOX_APP_SECRET}"
+    },
+    "include_filter": "pdf,docx,txt",
+    "max_files": 500
+  }
+}
+```
+
+### Single file
+
+```json
+{
+  "type": "ingest_source",
+  "name": "ingest",
+  "config": {
+    "provider": "dropbox",
+    "connection_params": { "file_path": "/Reports/q1.pdf" },
+    "credentials": { "access_token": "${DROPBOX_ACCESS_TOKEN}" }
+  }
+}
+```
+
+## Document Metadata
+
+| Field | Description |
+|-------|-------------|
+| `id` | Dropbox file id (e.g. `id:abc123`), stable across renames and moves |
+| `name` | File name |
+| `source_url` | `https://www.dropbox.com/home/<path>` |
+| `modified_time` | Dropbox `server_modified` timestamp |
+| `created_time` | Dropbox `client_modified` timestamp |
+| `metadata.source_id` | Dropbox file id used for on-demand binary retrieval |
+| `metadata.path` | Full Dropbox display path |
+| `metadata.relative_path` | Path relative to the configured `folder_path` |
+| `metadata.rev` | Dropbox file revision |
+| `metadata.content_hash` | Dropbox content hash |
+
+## Dependencies
+
+```bash
+pip install dropbox
+```
+
+The `dropbox` package is declared in `pyproject.toml` and installed with the project.
+
+## Troubleshooting
+
+### `Dropbox authentication failed`
+
+- The access token expired — short-lived tokens last four hours; switch to the refresh-token flow.
+- The token belongs to a different app than the configured `app_key` / `app_secret`.
+- The required scopes were added after the token was issued; re-issue the token after saving permissions.
+
+### `Dropbox API error, check that '/Folder' exists and is readable`
+
+- The path is case-insensitive but must exist; verify it in the Dropbox web UI.
+- Apps created with **App folder** access see paths relative to their own app folder, not the account root.
+- Use `""` (or `/`) for the account root — Dropbox rejects a literal `"/"` path in API calls, which the config normalizes for you.
+
+### No documents ingested
+
+- `include_filter` extensions are matched case-insensitively against the file suffix; check for files with no extension.
+- `exclude_patterns` are matched against both the full display path and the file name.
+- `recursive: false` lists only the immediate folder contents.
+
+## See Also
+
+- [Dropbox API documentation](https://www.dropbox.com/developers/documentation/http/documentation)
+- [Dropbox Python SDK](https://dropbox-sdk-python.readthedocs.io/)
+- [IngestSource operator documentation](../../../../../../../../../docs/operators/ingest/ingest_source_readme.md)

--- a/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/__init__.py
+++ b/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/__init__.py
@@ -1,0 +1,10 @@
+"""Dropbox source adapter for document ingestion."""
+
+try:
+    from .adapter import DropboxSourceAdapter
+    from .config import DropboxSourceConfig
+
+    __all__ = ["DropboxSourceAdapter", "DropboxSourceConfig"]
+except ImportError:
+    # Dropbox SDK dependencies not installed
+    __all__ = []

--- a/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/adapter.py
+++ b/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/adapter.py
@@ -1,0 +1,338 @@
+"""Dropbox source adapter using the official Dropbox Python SDK."""
+
+import hashlib
+import mimetypes
+from collections.abc import AsyncGenerator, Iterator
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+from dropbox import Dropbox
+from dropbox.exceptions import ApiError, AuthError, BadInputError, HttpError
+from dropbox.files import FileMetadata
+
+from docpipe.core.operators.ingest.adapters.outbound.sources.dropbox.config import DropboxSourceConfig
+from docpipe.core.operators.ingest.adapters.outbound.sources.factories.source_factory import register_source_adapter
+from docpipe.core.operators.ingest.domain.models import Document
+from docpipe.core.operators.ingest.ports.outbound.document_source import DocumentSourcePort
+from docpipe.core.operators.operator_utils import resolve_env_var
+from docpipe.utils.infrastructure.logging import get_logger
+
+logger = get_logger()
+
+# Dropbox user agent identifier sent with every API call.
+DROPBOX_CLIENT_IDENTIFIER = "docling-pipelines"
+
+
+@register_source_adapter
+class DropboxSourceAdapter(DocumentSourcePort[DropboxSourceConfig]):
+    """Adapter for ingesting documents from Dropbox using the Dropbox SDK."""
+
+    SOURCE_NAME = "dropbox"
+    SOURCE_DISPLAY_NAME = "Dropbox"
+    SOURCE_DESCRIPTION = "Ingest documents from a Dropbox account folder"
+    SOURCE_VERSION = "1.0.0"
+    CONFIG_CLASS = DropboxSourceConfig
+
+    def __init__(self) -> None:
+        # Cache authenticated Dropbox clients keyed by a credential fingerprint so a single
+        # client (and its token refresh state) is reused for all documents in a batch.
+        self._client_cache: dict[str, Dropbox] = {}
+
+    # ------------------------------------------------------------------
+    # Client handling
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _client_cache_key(*, config: DropboxSourceConfig) -> str:
+        """Build a non-reversible cache key from the configured credentials."""
+        material = "|".join(
+            [
+                config.access_token or "",
+                config.refresh_token or "",
+                config.app_key or "",
+            ]
+        )
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    def _get_dropbox_client(self, *, config: DropboxSourceConfig) -> Dropbox:
+        """Return a cached authenticated Dropbox client for the given credentials."""
+        key = self._client_cache_key(config=config)
+        if key not in self._client_cache:
+            if config.refresh_token:
+                client = Dropbox(
+                    oauth2_refresh_token=config.refresh_token,
+                    app_key=config.app_key,
+                    app_secret=config.app_secret,
+                    user_agent=DROPBOX_CLIENT_IDENTIFIER,
+                )
+            else:
+                client = Dropbox(
+                    oauth2_access_token=config.access_token,
+                    user_agent=DROPBOX_CLIENT_IDENTIFIER,
+                )
+            self._client_cache[key] = client
+        return self._client_cache[key]
+
+    # ------------------------------------------------------------------
+    # Filtering helpers
+    # ------------------------------------------------------------------
+
+    def _should_include_file(self, *, entry: FileMetadata, config: DropboxSourceConfig) -> bool:
+        """Check whether a Dropbox file passes extension, size and exclusion filters."""
+        file_name = entry.name or ""
+        file_ext = Path(file_name).suffix.lower()
+
+        if config.file_extensions and file_ext not in config.file_extensions:
+            return False
+
+        file_size = entry.size or 0
+        if config.max_file_size_mb is not None and file_size / (1024 * 1024) > config.max_file_size_mb:
+            return False
+
+        if config.exclude_patterns:
+            candidate_path = entry.path_display or entry.path_lower or file_name
+            for pattern in config.exclude_patterns:
+                if fnmatch(candidate_path, pattern) or fnmatch(file_name, pattern):
+                    return False
+
+        return True
+
+    def _iter_dropbox_files(self, *, client: Dropbox, config: DropboxSourceConfig) -> Iterator[FileMetadata]:
+        """Iterate Dropbox files under the configured folder, following pagination cursors."""
+        result = client.files_list_folder(path=config.folder_path, recursive=config.recursive)
+
+        while True:
+            for entry in result.entries:
+                if not isinstance(entry, FileMetadata):
+                    continue
+                if self._should_include_file(entry=entry, config=config):
+                    yield entry
+
+            if not result.has_more:
+                return
+
+            result = client.files_list_folder_continue(result.cursor)
+
+    # ------------------------------------------------------------------
+    # Document mapping
+    # ------------------------------------------------------------------
+
+    def _compute_relative_path(self, *, entry: FileMetadata, folder_path: str) -> str:
+        """Compute the file path relative to the configured root folder."""
+        display_path = entry.path_display or entry.path_lower or entry.name or ""
+        relative = display_path.lstrip("/")
+
+        if folder_path:
+            root = folder_path.strip("/")
+            lowered = relative.lower()
+            if lowered.startswith(f"{root.lower()}/"):
+                relative = relative[len(root) + 1 :]
+            elif lowered == root.lower():
+                relative = entry.name or relative
+
+        return relative
+
+    def _prepare_document(self, *, entry: FileMetadata, config: DropboxSourceConfig) -> Document:
+        """Convert Dropbox file metadata to the domain document model (lazy loading).
+
+        No binary content is downloaded here. Content is fetched on-demand by the
+        Extract operator via fetch_binary_content().
+        """
+        doc_id = entry.id or entry.path_lower or entry.name
+        doc_name = entry.name or "unknown"
+        display_path = entry.path_display or entry.path_lower or f"/{doc_name}"
+        source_url = f"https://www.dropbox.com/home{display_path}"
+        size = entry.size or 0
+        mimetype = mimetypes.guess_type(doc_name)[0] or "application/octet-stream"
+        relative_path = self._compute_relative_path(entry=entry, folder_path=config.folder_path)
+
+        client_modified = getattr(entry, "client_modified", None)
+        server_modified = getattr(entry, "server_modified", None)
+
+        return Document(
+            id=doc_id,
+            name=doc_name,
+            content=b"",  # Empty - binary loaded on-demand by downstream operators
+            source_url=source_url,
+            size=size,
+            mimetype=mimetype,
+            extension=Path(doc_name).suffix.lstrip("."),
+            modified_time=server_modified,
+            created_time=client_modified,
+            metadata={
+                "source": source_url,  # Required for document_url in failed_docs
+                "source_id": doc_id,  # Required by binary_content_fetcher
+                "dropbox_id": entry.id,
+                "dropbox_name": doc_name,
+                "path": display_path,
+                "relative_path": relative_path,
+                "size": size,
+                "client_modified": client_modified.isoformat() if client_modified else None,
+                "server_modified": server_modified.isoformat() if server_modified else None,
+                "rev": getattr(entry, "rev", None),
+                "content_hash": getattr(entry, "content_hash", None),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Port implementation
+    # ------------------------------------------------------------------
+
+    async def fetch_documents(self, config: DropboxSourceConfig) -> AsyncGenerator[Document, None]:  # type: ignore[override]
+        """Fetch document metadata from Dropbox, streaming results as they are listed."""
+        try:
+            client = self._get_dropbox_client(config=config)
+
+            # Single file mode
+            if config.file_path:
+                logger.info("Fetching single file from Dropbox: %s", config.file_path)
+                entry = client.files_get_metadata(config.file_path)
+                if not isinstance(entry, FileMetadata):
+                    raise ValueError(f"Dropbox path is not a file: {config.file_path}")
+                yield self._prepare_document(entry=entry, config=config)
+                return
+
+            # Folder mode
+            doc_count = 0
+            for entry in self._iter_dropbox_files(client=client, config=config):
+                if config.max_files is not None and doc_count >= config.max_files:
+                    break
+                yield self._prepare_document(entry=entry, config=config)
+                doc_count += 1
+
+            logger.info(
+                "Fetched %s document(s) from Dropbox folder '%s'",
+                doc_count,
+                config.folder_path or "/",
+            )
+
+        except AuthError as e:
+            logger.error("Dropbox authentication failed: %s", e)
+            raise ValueError(f"Dropbox authentication failed: {e!s}") from e
+        except (ApiError, BadInputError, HttpError) as e:
+            logger.error("Dropbox API error while listing documents: %s", e)
+            raise ValueError(f"Failed to fetch documents from Dropbox: {e!s}") from e
+
+    async def test_connection(self, config: DropboxSourceConfig) -> tuple[bool, str]:
+        """Test the Dropbox connection with the cheapest read-only calls available."""
+        try:
+            client = self._get_dropbox_client(config=config)
+            account = client.users_get_current_account()
+            display_name = getattr(getattr(account, "name", None), "display_name", "unknown account")
+
+            if config.folder_path:
+                client.files_get_metadata(config.folder_path)
+
+            return True, f"Successfully connected to Dropbox as {display_name}"
+        except AuthError as e:
+            return False, f"Dropbox authentication failed, check the configured token: {e!s}"
+        except BadInputError as e:
+            return False, f"Invalid Dropbox credentials or request: {e!s}"
+        except ApiError as e:
+            return False, f"Dropbox API error, check that '{config.folder_path or '/'}' exists and is readable: {e!s}"
+        except HttpError as e:
+            return False, f"Could not reach the Dropbox API: {e!s}"
+        except Exception as e:  # Connection test must never raise
+            return False, f"Connection test failed: {e!s}"
+
+    def get_config_schema(self) -> type[DropboxSourceConfig]:
+        """Get the configuration schema for this adapter."""
+        return DropboxSourceConfig
+
+    def build_config_from_operator_params(
+        self,
+        *,
+        connection_params: dict,
+        credentials: dict,
+        included_extensions: list[str] | None = None,
+        max_files: int | None = None,
+    ) -> DropboxSourceConfig:
+        """Build the Dropbox configuration from operator parameters."""
+        config_dict: dict[str, Any] = {
+            "access_token": resolve_env_var(credentials.get("access_token")),
+            "refresh_token": resolve_env_var(credentials.get("refresh_token")),
+            "app_key": resolve_env_var(credentials.get("app_key")),
+            "app_secret": resolve_env_var(credentials.get("app_secret")),
+            "folder_path": resolve_env_var(connection_params.get("folder_path", "")) or "",
+            "recursive": connection_params.get("recursive", True),
+            "file_extensions": included_extensions or [],
+            "exclude_patterns": connection_params.get("exclude_patterns", []),
+        }
+
+        # Support single file ingestion via file_path
+        if connection_params.get("file_path"):
+            config_dict["file_path"] = resolve_env_var(connection_params["file_path"])
+
+        if "max_file_size_mb" in connection_params:
+            config_dict["max_file_size_mb"] = connection_params["max_file_size_mb"]
+
+        if max_files is not None:
+            config_dict["max_files"] = max_files
+
+        return DropboxSourceConfig(**config_dict)
+
+    def fetch_binary_content(
+        self,
+        *,
+        source_id: str,
+        connection_params: dict[str, Any],
+        credentials: dict[str, Any],
+    ) -> bytes | None:
+        """
+        Fetch binary content for a specific Dropbox file on-demand.
+
+        Args:
+            source_id: Dropbox file id (e.g. "id:abc123"), file path, or file URL
+            connection_params: Dropbox connection parameters (not used for downloads)
+            credentials: Dropbox credentials (access_token, or refresh_token + app_key + app_secret)
+
+        Returns:
+            bytes | None: Binary content of the file, or None if it could not be downloaded
+
+        Raises:
+            ValueError: If credentials are missing or source_id is empty
+        """
+        if not source_id:
+            raise ValueError("Missing source_id for Dropbox binary content fetch")
+
+        config = self.build_config_from_operator_params(
+            connection_params={},
+            credentials=credentials,
+        )
+
+        file_ref = self._normalize_source_id(source_id=source_id)
+
+        try:
+            client = self._get_dropbox_client(config=config)
+            logger.info("Downloading binary content from Dropbox: %s", file_ref)
+            _, response = client.files_download(file_ref)
+            content = response.content
+            logger.info("Successfully downloaded %s bytes from Dropbox", len(content))
+            return content
+        except AuthError as e:
+            logger.error("Dropbox authentication failed while downloading %s: %s", file_ref, e)
+            return None
+        except ApiError as e:
+            logger.error("Dropbox file could not be downloaded (%s): %s", file_ref, e)
+            return None
+        except (BadInputError, HttpError) as e:
+            logger.error("Dropbox API error while downloading %s: %s", file_ref, e)
+            return None
+
+    @staticmethod
+    def _normalize_source_id(*, source_id: str) -> str:
+        """Convert a stored source identifier into a reference the Dropbox API accepts."""
+        reference = source_id.strip()
+
+        # Documents ingested by this adapter store the Dropbox file id, which is accepted as-is.
+        if reference.startswith(("id:", "rev:", "ns:")):
+            return reference
+
+        # Documents referenced by their Dropbox web URL (https://www.dropbox.com/home/<path>).
+        if reference.startswith("http"):
+            _, _, path_part = reference.partition("/home")
+            path_part = path_part.split("?", 1)[0]
+            reference = path_part or reference
+
+        return reference if reference.startswith("/") else f"/{reference}"

--- a/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/config.py
+++ b/src/docpipe/core/operators/ingest/adapters/outbound/sources/dropbox/config.py
@@ -1,0 +1,148 @@
+"""Configuration model for the Dropbox source adapter."""
+
+from typing import ClassVar
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class DropboxSourceConfig(BaseModel):
+    """
+    Type-safe configuration for the Dropbox document source.
+
+    Two authentication modes are supported:
+    - Short-lived / legacy token: provide ``access_token``.
+    - Long-lived refresh flow: provide ``refresh_token``, ``app_key`` and ``app_secret``.
+      The SDK then refreshes the access token automatically.
+    """
+
+    # Credentials (never included in repr to keep secrets out of logs and tracebacks)
+    access_token: str | None = Field(
+        None, repr=False, description="Dropbox OAuth2 access token (short-lived or legacy long-lived token)"
+    )
+
+    refresh_token: str | None = Field(
+        None, repr=False, description="Dropbox OAuth2 refresh token. Requires app_key and app_secret."
+    )
+
+    app_key: str | None = Field(None, repr=False, description="Dropbox app key, required when using refresh_token")
+
+    app_secret: str | None = Field(
+        None, repr=False, description="Dropbox app secret, required when using refresh_token"
+    )
+
+    # Dropbox location configuration
+    folder_path: str = Field(
+        "",
+        description="Dropbox folder path to ingest from (e.g. '/Reports'). Empty string means the account root.",
+    )
+
+    file_path: str | None = Field(
+        None,
+        description=(
+            "Specific Dropbox file path (e.g. '/Reports/q1.pdf') or file id (e.g. 'id:abc123') to ingest. "
+            "If provided, only this file is processed (ignores folder_path, recursive and filter settings)."
+        ),
+    )
+
+    # Behavior configuration
+    recursive: bool = Field(True, description="Whether to recursively traverse subfolders")
+
+    file_extensions: list[str] = Field(
+        default_factory=list,
+        description="List of file extensions to include (e.g., ['.pdf', '.docx']). Empty list means all files.",
+    )
+
+    exclude_patterns: list[str] = Field(
+        default_factory=list, description="List of glob patterns to exclude (e.g., ['*.tmp', '*/Archive/*'])"
+    )
+
+    max_file_size_mb: int | None = Field(None, description="Maximum file size in MB to process. None means no limit.")
+
+    max_files: int | None = Field(None, description="Maximum number of files to fetch. None means no limit.")
+
+    @field_validator("access_token", "refresh_token", "app_key", "app_secret")
+    @classmethod
+    def normalize_optional_credential(cls, v: str | None) -> str | None:
+        """Treat blank credential strings as not provided."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped or None
+
+    @field_validator("folder_path")
+    @classmethod
+    def validate_folder_path(cls, v: str) -> str:
+        """Normalize the folder path to Dropbox API conventions (root is an empty string)."""
+        path = (v or "").strip()
+        if path in ("", "/"):
+            return ""
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return path.rstrip("/")
+
+    @field_validator("file_path")
+    @classmethod
+    def validate_file_path(cls, v: str | None) -> str | None:
+        """Normalize a single-file path, leaving Dropbox file ids untouched."""
+        if v is None:
+            return None
+        path = v.strip()
+        if not path:
+            return None
+        if path.startswith(("id:", "rev:", "ns:")):
+            return path
+        return path if path.startswith("/") else f"/{path}"
+
+    @field_validator("file_extensions")
+    @classmethod
+    def validate_extensions(cls, v: list[str]) -> list[str]:
+        """Ensure extensions are lowercase and start with a dot."""
+        return [ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in v]
+
+    @field_validator("max_file_size_mb")
+    @classmethod
+    def validate_max_file_size(cls, v: int | None) -> int | None:
+        """Validate max file size is positive."""
+        if v is not None and v <= 0:
+            raise ValueError("max_file_size_mb must be positive")
+        return v
+
+    @field_validator("max_files")
+    @classmethod
+    def validate_max_files(cls, v: int | None) -> int | None:
+        """Validate max files is positive."""
+        if v is not None and v <= 0:
+            raise ValueError("max_files must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_credentials(self) -> "DropboxSourceConfig":
+        """Ensure a usable authentication mode is configured."""
+        if self.access_token:
+            return self
+
+        if self.refresh_token:
+            missing = [name for name in ("app_key", "app_secret") if not getattr(self, name)]
+            if missing:
+                raise ValueError(f"refresh_token authentication requires {' and '.join(missing)}")
+            return self
+
+        raise ValueError(
+            "Dropbox credentials missing: provide 'access_token', or 'refresh_token' together with "
+            "'app_key' and 'app_secret'"
+        )
+
+    class Config:
+        """Pydantic configuration."""
+
+        json_schema_extra: ClassVar[dict] = {
+            "example": {
+                "access_token": "${DROPBOX_ACCESS_TOKEN}",  # pragma: allowlist secret  # nosec B105 - env var reference in a schema example, not a credential
+                "folder_path": "/Reports",
+                "recursive": True,
+                "file_extensions": [".pdf", ".docx", ".txt"],
+                "exclude_patterns": ["*.tmp", "*/Archive/*"],
+                "max_file_size_mb": 100,
+                "max_files": 100,
+            }
+        }

--- a/src/docpipe/core/operators/ingest/ingest_source.py
+++ b/src/docpipe/core/operators/ingest/ingest_source.py
@@ -256,7 +256,7 @@ MAX_FILES_DEFAULT_VALUE: int = 100
 INCLUDE_FILTER_KEY: str = "include_filter"
 EXCLUDE_FILTER_KEY: str = "exclude_filter"
 ADAPTER_MANAGED_PROVIDERS: frozenset[str] = frozenset(
-    {"s3", "ibm_cos", "sharepoint", "onedrive", "google_drive", "box_driver", "filesystem", "web"}
+    {"s3", "ibm_cos", "sharepoint", "onedrive", "google_drive", "box_driver", "dropbox", "filesystem", "web"}
 )
 
 logger = get_logger()

--- a/tests/unit/operators/ingest/test_dropbox_source_adapter.py
+++ b/tests/unit/operators/ingest/test_dropbox_source_adapter.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Unit tests for the Dropbox ingest source adapter.
+
+All Dropbox SDK calls are mocked - these tests never contact the live provider.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from dropbox.exceptions import ApiError, AuthError, HttpError
+from dropbox.files import FileMetadata, FolderMetadata
+
+from docpipe.core.operators.ingest.adapters.outbound.sources.dropbox.adapter import DropboxSourceAdapter
+from docpipe.core.operators.ingest.adapters.outbound.sources.dropbox.config import DropboxSourceConfig
+from docpipe.core.operators.ingest.adapters.outbound.sources.factories.source_factory import SourceAdapterFactory
+
+ADAPTER_MODULE = "docpipe.core.operators.ingest.adapters.outbound.sources.dropbox.adapter"
+
+
+def make_file(
+    *,
+    name: str,
+    path: str,
+    file_id: str = "id:file1",
+    size: int = 1024,
+    modified: datetime | None = None,
+) -> FileMetadata:
+    """Build a Dropbox FileMetadata entry for tests."""
+    timestamp = modified or datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+    return FileMetadata(
+        name=name,
+        id=file_id,
+        path_lower=path.lower(),
+        path_display=path,
+        size=size,
+        client_modified=timestamp,
+        server_modified=timestamp,
+        rev="0123456789abc",
+        content_hash="a" * 64,
+    )
+
+
+def make_list_result(entries, *, has_more: bool = False, cursor: str = "cursor-1") -> Mock:
+    """Build a mock files_list_folder result."""
+    result = Mock()
+    result.entries = entries
+    result.has_more = has_more
+    result.cursor = cursor
+    return result
+
+
+def make_api_error(message: str = "dropbox api error") -> ApiError:
+    """Build an ApiError instance without depending on SDK error union internals."""
+    return ApiError(request_id="req-1", error=message, user_message_text=None, user_message_locale=None)
+
+
+async def collect(generator):
+    """Collect an async generator into a list."""
+    return [item async for item in generator]
+
+
+def base_config(**overrides) -> DropboxSourceConfig:
+    """Build a config with a token and optional overrides."""
+    params = {"access_token": "test-token", "folder_path": "/Reports"}  # pragma: allowlist secret
+    params.update(overrides)
+    return DropboxSourceConfig(**params)
+
+
+class TestDropboxSourceConfig:
+    """Test DropboxSourceConfig validation, defaults and normalization."""
+
+    def test_requires_credentials(self):
+        """Config without any credential is rejected with an actionable message."""
+        with pytest.raises(ValueError, match="Dropbox credentials missing"):
+            DropboxSourceConfig()
+
+    def test_refresh_token_requires_app_key_and_secret(self):
+        """Refresh token flow requires the app key and secret."""
+        with pytest.raises(ValueError, match="app_key and app_secret"):
+            DropboxSourceConfig(refresh_token="refresh")  # pragma: allowlist secret
+
+    def test_refresh_token_flow_accepted(self):
+        """Refresh token flow is valid when app credentials are present."""
+        config = DropboxSourceConfig(
+            refresh_token="refresh",  # pragma: allowlist secret
+            app_key="key",
+            app_secret="secret",  # pragma: allowlist secret
+        )
+        assert config.refresh_token == "refresh"
+        assert config.access_token is None
+
+    def test_blank_credentials_treated_as_missing(self):
+        """Whitespace-only credentials are not accepted as a token."""
+        with pytest.raises(ValueError, match="Dropbox credentials missing"):
+            DropboxSourceConfig(access_token="   ")
+
+    def test_folder_path_root_is_empty_string(self):
+        """Dropbox represents the account root as an empty path."""
+        assert base_config(folder_path="/").folder_path == ""
+        assert base_config(folder_path="").folder_path == ""
+
+    def test_folder_path_normalized(self):
+        """Folder paths gain a leading slash and lose trailing slashes."""
+        assert base_config(folder_path="Reports/2026/").folder_path == "/Reports/2026"
+
+    def test_file_path_normalized_and_file_id_preserved(self):
+        """File paths are normalized while Dropbox file ids are left untouched."""
+        assert base_config(file_path="Reports/q1.pdf").file_path == "/Reports/q1.pdf"
+        assert base_config(file_path="id:abc123").file_path == "id:abc123"
+
+    def test_extensions_normalized(self):
+        """Extensions are lowercased and prefixed with a dot."""
+        config = base_config(file_extensions=["PDF", ".DocX", "txt"])
+        assert config.file_extensions == [".pdf", ".docx", ".txt"]
+
+    def test_validates_max_file_size(self):
+        """max_file_size_mb must be positive."""
+        with pytest.raises(ValueError, match="max_file_size_mb must be positive"):
+            base_config(max_file_size_mb=0)
+
+    def test_validates_max_files(self):
+        """max_files must be positive."""
+        with pytest.raises(ValueError, match="max_files must be positive"):
+            base_config(max_files=-3)
+
+    def test_secrets_hidden_from_repr(self):
+        """Credentials must not leak through the model repr."""
+        config = base_config(access_token="super-secret-token")  # pragma: allowlist secret
+        assert "super-secret-token" not in repr(config)
+
+
+class TestDropboxAdapterMetadata:
+    """Test adapter identity, schema and factory registration."""
+
+    def test_source_metadata(self):
+        """Adapter exposes the discovery metadata used by the UI."""
+        metadata = DropboxSourceAdapter().get_metadata()
+        assert metadata["name"] == "dropbox"
+        assert metadata["display_name"] == "Dropbox"
+        assert metadata["config_schema"] is not None
+
+    def test_get_config_schema(self):
+        """Adapter returns its Pydantic config class."""
+        assert DropboxSourceAdapter().get_config_schema() is DropboxSourceConfig
+
+    def test_registered_with_factory(self):
+        """Adapter is discoverable by SOURCE_NAME through the factory."""
+        assert SourceAdapterFactory.is_registered("dropbox")
+        assert isinstance(SourceAdapterFactory.create("dropbox"), DropboxSourceAdapter)
+
+
+class TestBuildConfigFromOperatorParams:
+    """Test mapping of operator parameters onto the provider config."""
+
+    def test_maps_connection_params_and_credentials(self):
+        """Operator parameters are mapped onto the Dropbox config."""
+        config = DropboxSourceAdapter().build_config_from_operator_params(
+            connection_params={
+                "folder_path": "Reports",
+                "recursive": False,
+                "exclude_patterns": ["*.tmp"],
+                "max_file_size_mb": 50,
+            },
+            credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            included_extensions=["pdf", "docx"],
+            max_files=25,
+        )
+
+        assert isinstance(config, DropboxSourceConfig)
+        assert config.folder_path == "/Reports"
+        assert config.recursive is False
+        assert config.exclude_patterns == ["*.tmp"]
+        assert config.max_file_size_mb == 50
+        assert config.file_extensions == [".pdf", ".docx"]
+        assert config.max_files == 25
+
+    def test_defaults_to_root_and_recursive(self):
+        """Missing connection params fall back to a recursive root ingestion."""
+        config = DropboxSourceAdapter().build_config_from_operator_params(
+            connection_params={},
+            credentials={"access_token": "token-value"},  # pragma: allowlist secret
+        )
+        assert config.folder_path == ""
+        assert config.recursive is True
+        assert config.max_files is None
+
+    def test_resolves_environment_variables(self, monkeypatch):
+        """Credential and path environment references are resolved."""
+        monkeypatch.setenv("DROPBOX_TEST_TOKEN", "resolved-token")
+        monkeypatch.setenv("DROPBOX_TEST_FOLDER", "/Env/Folder")
+
+        config = DropboxSourceAdapter().build_config_from_operator_params(
+            connection_params={"folder_path": "${DROPBOX_TEST_FOLDER}"},
+            credentials={"access_token": "${DROPBOX_TEST_TOKEN}"},  # pragma: allowlist secret
+        )
+
+        assert config.access_token == "resolved-token"
+        assert config.folder_path == "/Env/Folder"
+
+    def test_missing_credentials_raise_value_error(self):
+        """A flow without Dropbox credentials fails with an actionable error."""
+        with pytest.raises(ValueError, match="Dropbox credentials missing"):
+            DropboxSourceAdapter().build_config_from_operator_params(
+                connection_params={"folder_path": "/Reports"},
+                credentials={},
+            )
+
+    def test_single_file_mode_param(self):
+        """file_path in connection params enables single-file ingestion."""
+        config = DropboxSourceAdapter().build_config_from_operator_params(
+            connection_params={"file_path": "Reports/q1.pdf"},
+            credentials={"access_token": "token-value"},  # pragma: allowlist secret
+        )
+        assert config.file_path == "/Reports/q1.pdf"
+
+
+class TestTestConnection:
+    """Test the connection check behavior."""
+
+    @pytest.mark.asyncio
+    async def test_connection_success(self):
+        """A successful account lookup reports the account display name."""
+        client = Mock()
+        client.users_get_current_account.return_value.name.display_name = "Test User"
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            success, message = await DropboxSourceAdapter().test_connection(base_config())
+
+        assert success is True
+        assert "Test User" in message
+        client.files_get_metadata.assert_called_once_with("/Reports")
+
+    @pytest.mark.asyncio
+    async def test_connection_skips_folder_check_at_root(self):
+        """Root ingestion does not need an extra metadata call."""
+        client = Mock()
+        client.users_get_current_account.return_value.name.display_name = "Test User"
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            success, _ = await DropboxSourceAdapter().test_connection(base_config(folder_path=""))
+
+        assert success is True
+        client.files_get_metadata.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connection_auth_failure(self):
+        """Authentication failures return an actionable message."""
+        client = Mock()
+        client.users_get_current_account.side_effect = AuthError("req-1", "invalid_access_token")
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            success, message = await DropboxSourceAdapter().test_connection(base_config())
+
+        assert success is False
+        assert "authentication failed" in message.lower()
+
+    @pytest.mark.asyncio
+    async def test_connection_missing_folder(self):
+        """A missing folder is reported rather than raised."""
+        client = Mock()
+        client.users_get_current_account.return_value.name.display_name = "Test User"
+        client.files_get_metadata.side_effect = make_api_error("path/not_found")
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            success, message = await DropboxSourceAdapter().test_connection(base_config())
+
+        assert success is False
+        assert "/Reports" in message
+
+    @pytest.mark.asyncio
+    async def test_connection_network_failure(self):
+        """Transport errors are reported as a failed connection."""
+        client = Mock()
+        client.users_get_current_account.side_effect = HttpError("req-1", 503, "service unavailable")
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            success, message = await DropboxSourceAdapter().test_connection(base_config())
+
+        assert success is False
+        assert "Dropbox API" in message
+
+
+class TestFetchDocuments:
+    """Test document listing, filtering, pagination and mapping."""
+
+    @pytest.mark.asyncio
+    async def test_yields_documents_with_domain_metadata(self):
+        """Listed files are mapped to fully populated domain documents."""
+        entry = make_file(name="q1.pdf", path="/Reports/2026/q1.pdf", file_id="id:abc123", size=2048)
+        client = Mock()
+        client.files_list_folder.return_value = make_list_result([entry])
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(base_config()))
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc.id == "id:abc123"
+        assert doc.name == "q1.pdf"
+        assert doc.content == b""
+        assert doc.size == 2048
+        assert doc.extension == "pdf"
+        assert doc.mimetype == "application/pdf"
+        assert doc.modified_time == datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        assert doc.source_url == "https://www.dropbox.com/home/Reports/2026/q1.pdf"
+        assert doc.metadata["source_id"] == "id:abc123"
+        assert doc.metadata["path"] == "/Reports/2026/q1.pdf"
+        assert doc.metadata["relative_path"] == "2026/q1.pdf"
+        assert doc.metadata["rev"] == "0123456789abc"
+        client.files_list_folder.assert_called_once_with(path="/Reports", recursive=True)
+
+    @pytest.mark.asyncio
+    async def test_follows_pagination_cursor(self):
+        """Additional pages are fetched with the continuation cursor."""
+        page_one = make_list_result(
+            [make_file(name="a.pdf", path="/Reports/a.pdf", file_id="id:a")],
+            has_more=True,
+            cursor="cursor-1",
+        )
+        page_two = make_list_result([make_file(name="b.pdf", path="/Reports/b.pdf", file_id="id:b")])
+
+        client = Mock()
+        client.files_list_folder.return_value = page_one
+        client.files_list_folder_continue.return_value = page_two
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(base_config()))
+
+        assert [doc.name for doc in docs] == ["a.pdf", "b.pdf"]
+        client.files_list_folder_continue.assert_called_once_with("cursor-1")
+
+    @pytest.mark.asyncio
+    async def test_skips_folders_and_applies_extension_filter(self):
+        """Folder entries are ignored and extension filters are enforced."""
+        entries = [
+            FolderMetadata(name="sub", id="id:folder", path_lower="/reports/sub", path_display="/Reports/sub"),
+            make_file(name="keep.pdf", path="/Reports/keep.pdf", file_id="id:keep"),
+            make_file(name="skip.png", path="/Reports/skip.png", file_id="id:skip"),
+        ]
+        client = Mock()
+        client.files_list_folder.return_value = make_list_result(entries)
+
+        config = base_config(file_extensions=["pdf"])
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(config))
+
+        assert [doc.name for doc in docs] == ["keep.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_applies_size_and_exclude_filters(self):
+        """Oversized files and excluded paths are filtered out."""
+        entries = [
+            make_file(name="small.pdf", path="/Reports/small.pdf", file_id="id:small", size=1024),
+            make_file(name="huge.pdf", path="/Reports/huge.pdf", file_id="id:huge", size=5 * 1024 * 1024),
+            make_file(name="old.pdf", path="/Reports/Archive/old.pdf", file_id="id:old", size=1024),
+        ]
+        client = Mock()
+        client.files_list_folder.return_value = make_list_result(entries)
+
+        config = base_config(max_file_size_mb=1, exclude_patterns=["*/Archive/*"])
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(config))
+
+        assert [doc.name for doc in docs] == ["small.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_respects_max_files(self):
+        """Listing stops once max_files documents have been produced."""
+        entries = [make_file(name=f"f{i}.pdf", path=f"/Reports/f{i}.pdf", file_id=f"id:{i}") for i in range(5)]
+        client = Mock()
+        client.files_list_folder.return_value = make_list_result(entries)
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(base_config(max_files=2)))
+
+        assert len(docs) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_recursive_listing(self):
+        """recursive=False is forwarded to the Dropbox API."""
+        client = Mock()
+        client.files_list_folder.return_value = make_list_result([])
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(base_config(recursive=False)))
+
+        assert docs == []
+        client.files_list_folder.assert_called_once_with(path="/Reports", recursive=False)
+
+    @pytest.mark.asyncio
+    async def test_single_file_mode(self):
+        """A configured file_path fetches exactly one document."""
+        client = Mock()
+        client.files_get_metadata.return_value = make_file(name="q1.pdf", path="/Reports/q1.pdf", file_id="id:single")
+
+        config = base_config(file_path="/Reports/q1.pdf")
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            docs = await collect(DropboxSourceAdapter().fetch_documents(config))
+
+        assert [doc.id for doc in docs] == ["id:single"]
+        client.files_list_folder.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_file_mode_rejects_folder(self):
+        """Pointing file_path at a folder raises a clear error."""
+        client = Mock()
+        client.files_get_metadata.return_value = FolderMetadata(
+            name="sub", id="id:folder", path_lower="/reports/sub", path_display="/Reports/sub"
+        )
+
+        config = base_config(file_path="/Reports/sub")
+        with (
+            patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client),
+            pytest.raises(ValueError, match="not a file"),
+        ):
+            await collect(DropboxSourceAdapter().fetch_documents(config))
+
+    @pytest.mark.asyncio
+    async def test_auth_error_is_raised(self):
+        """Authentication failures abort the listing with a clear error."""
+        client = Mock()
+        client.files_list_folder.side_effect = AuthError("req-1", "invalid_access_token")
+
+        with (
+            patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client),
+            pytest.raises(ValueError, match="authentication failed"),
+        ):
+            await collect(DropboxSourceAdapter().fetch_documents(base_config()))
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_raised(self):
+        """API errors during listing surface as a ValueError."""
+        client = Mock()
+        client.files_list_folder.side_effect = make_api_error()
+
+        with (
+            patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client),
+            pytest.raises(ValueError, match="Failed to fetch documents from Dropbox"),
+        ):
+            await collect(DropboxSourceAdapter().fetch_documents(base_config()))
+
+
+class TestFetchBinaryContent:
+    """Test on-demand binary retrieval."""
+
+    def test_downloads_by_file_id(self):
+        """A stored Dropbox file id is passed through unchanged."""
+        response = Mock()
+        response.content = b"PDF-bytes"
+        client = Mock()
+        client.files_download.return_value = (None, response)
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            content = DropboxSourceAdapter().fetch_binary_content(
+                source_id="id:abc123",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+        assert content == b"PDF-bytes"
+        client.files_download.assert_called_once_with("id:abc123")
+
+    def test_downloads_by_path(self):
+        """A bare path is normalized to a Dropbox path."""
+        response = Mock()
+        response.content = b"bytes"
+        client = Mock()
+        client.files_download.return_value = (None, response)
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            DropboxSourceAdapter().fetch_binary_content(
+                source_id="Reports/q1.pdf",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+        client.files_download.assert_called_once_with("/Reports/q1.pdf")
+
+    def test_downloads_by_web_url(self):
+        """A Dropbox web URL is converted back to a Dropbox path."""
+        response = Mock()
+        response.content = b"bytes"
+        client = Mock()
+        client.files_download.return_value = (None, response)
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            DropboxSourceAdapter().fetch_binary_content(
+                source_id="https://www.dropbox.com/home/Reports/q1.pdf",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+        client.files_download.assert_called_once_with("/Reports/q1.pdf")
+
+    def test_returns_none_when_file_missing(self):
+        """A missing file yields None so the pipeline can record the failure."""
+        client = Mock()
+        client.files_download.side_effect = make_api_error("path/not_found")
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            content = DropboxSourceAdapter().fetch_binary_content(
+                source_id="id:missing",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+        assert content is None
+
+    def test_returns_none_on_auth_error(self):
+        """Authentication failures during download yield None."""
+        client = Mock()
+        client.files_download.side_effect = AuthError("req-1", "invalid_access_token")
+
+        with patch.object(DropboxSourceAdapter, "_get_dropbox_client", return_value=client):
+            content = DropboxSourceAdapter().fetch_binary_content(
+                source_id="id:abc123",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+        assert content is None
+
+    def test_empty_source_id_raises(self):
+        """An empty source_id is a configuration error, not a missing file."""
+        with pytest.raises(ValueError, match="Missing source_id"):
+            DropboxSourceAdapter().fetch_binary_content(
+                source_id="",
+                connection_params={},
+                credentials={"access_token": "token-value"},  # pragma: allowlist secret
+            )
+
+    def test_missing_credentials_raise(self):
+        """Missing credentials stop processing with an actionable error."""
+        with pytest.raises(ValueError, match="Dropbox credentials missing"):
+            DropboxSourceAdapter().fetch_binary_content(
+                source_id="id:abc123",
+                connection_params={},
+                credentials={},
+            )
+
+
+class TestClientCaching:
+    """Test that a single authenticated client is reused per credential set."""
+
+    def test_client_is_cached_per_credentials(self):
+        """The SDK client is constructed once and reused for the same token."""
+        adapter = DropboxSourceAdapter()
+        config = base_config()
+
+        with patch(f"{ADAPTER_MODULE}.Dropbox") as mock_dropbox:
+            first = adapter._get_dropbox_client(config=config)
+            second = adapter._get_dropbox_client(config=config)
+
+        assert first is second
+        assert mock_dropbox.call_count == 1
+
+    def test_refresh_token_client_construction(self):
+        """Refresh token credentials are passed to the SDK client."""
+        adapter = DropboxSourceAdapter()
+        config = DropboxSourceConfig(
+            refresh_token="refresh",  # pragma: allowlist secret
+            app_key="key",
+            app_secret="secret",  # pragma: allowlist secret
+        )
+
+        with patch(f"{ADAPTER_MODULE}.Dropbox") as mock_dropbox:
+            adapter._get_dropbox_client(config=config)
+
+        kwargs = mock_dropbox.call_args.kwargs
+        assert kwargs["oauth2_refresh_token"] == "refresh"
+        assert kwargs["app_key"] == "key"

--- a/tests/unit/scripts/__init__.py
+++ b/tests/unit/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for repository scripts."""

--- a/tests/unit/scripts/test_test_examples.py
+++ b/tests/unit/scripts/test_test_examples.py
@@ -1,0 +1,55 @@
+"""Tests for the example test runner."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.test_examples import ExampleTest, ExampleTester
+from scripts.test_examples import TestCategory as ExampleCategory
+from scripts.test_examples import TestStatus as ExampleStatus
+
+
+def test_dry_run_skips_before_checking_prerequisites(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Dry-run mode must not probe external services or local prerequisites."""
+    tester = ExampleTester(dry_run=True)
+    test = ExampleTest(
+        name="Offline dry run",
+        path=tmp_path / "missing.py",
+        category=ExampleCategory.OPERATORS,
+        requires_ollama=True,
+        requires_opensearch=True,
+        requires_env=["MISSING_API_KEY"],
+    )
+
+    def fail_if_called(*, test: ExampleTest) -> tuple[bool, str | None]:
+        pytest.fail(f"check_prerequisites() unexpectedly called for {test.name}")
+
+    monkeypatch.setattr(tester, "check_prerequisites", fail_if_called)
+
+    result = tester.run_test(test=test)
+
+    assert result.status is ExampleStatus.SKIPPED
+    assert result.skip_reason == "Dry run mode"
+
+
+def test_normal_run_checks_prerequisites(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Non-dry runs must retain prerequisite checks."""
+    tester = ExampleTester()
+    test = ExampleTest(
+        name="Normal run",
+        path=tmp_path / "missing.py",
+        category=ExampleCategory.OPERATORS,
+    )
+    checked_tests: list[ExampleTest] = []
+
+    def check_prerequisites(*, test: ExampleTest) -> tuple[bool, str | None]:
+        checked_tests.append(test)
+        return False, "Prerequisite unavailable"
+
+    monkeypatch.setattr(tester, "check_prerequisites", check_prerequisites)
+
+    result = tester.run_test(test=test)
+
+    assert checked_tests == [test]
+    assert result.status is ExampleStatus.SKIPPED
+    assert result.skip_reason == "Prerequisite unavailable"


### PR DESCRIPTION
Closes #24

cc @Adityars-ibm

## Description

This PR introduces a native Dropbox source adapter for the `ingest_source` operator. It implements `DocumentSourcePort` and provides full integration with Dropbox API using `aiohttp` for lightweight asynchronous network operations.

### Key Features & Changes Included

* **`config.py` (`DropboxSourceConfig`)**:
  * Supports both OAuth Access Token and Refresh Token authentication modes.
  * Normalizes folder and file paths.
  * Filters files by extension, `max_files`, `max_file_size_mb`, and custom exclude glob patterns.
  * Excludes sensitive credential fields (`access_token`, `refresh_token`, `app_secret`) from string representations (`__repr__`).

* **`adapter.py` (`DropboxSourceAdapter`)**:
  * Registered under `"provider": "dropbox"` via `@register_source_adapter`.
  * Features cursor-based pagination for listing directories cleanly.
  * Implements lazy binary content loading.
  * Client caching based on credential fingerprint to avoid redundant authentication calls.
  * Supports single-file fetch mode.
  * Detailed, per-error-class error messages in `test_connection()`.

* **Tests**:
  * Added 43 unit tests covering configuration validation, factory registration, directory pagination, file filtering, authentication failure handling, binary retrieval (by ID, path, URL), and client caching.

* **Documentation**:
  * Added adapter documentation in `README.md`.
  * Updated `ingest_source_readme.md` (added Example 9 for Dropbox).
  * Updated `OPERATORS.md`, root `README.md`, `CHANGELOG.md`, and `CREATE_CONNECTOR_GUIDE.md`.

* **Dependencies**:
  * Updated `pyproject.toml` with `dropbox==12.1.0`.
  * Regenerated `requirements.txt`.

## Test Results

* **417 passed**, 6 failed (the 6 failures are pre-existing Windows path separator issues and missing pandas dependency, completely unrelated to this PR).

> **Note:** Live end-to-end validation is ready on a test Dropbox account. Let me know if you would like me to add a custom `conftest` marker to skip live API tests in CI pipelines.