### PR TITLE
test: add unit tests for ApiLoggingMiddleware and SecurityHeadersMidd…

### DIFF
--- a/tests/unit/api/middleware/test_api_logging_middleware.py
+++ b/tests/unit/api/middleware/test_api_logging_middleware.py
@@ -1,0 +1,169 @@
+"""Unit tests for ApiLoggingMiddleware."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.responses import Response
+
+from docpipe.api.middleware.api_logging_middleware import ApiLoggingMiddleware
+
+# The middleware uses logging.getLogger(__name__), which gives this logger name.
+_MIDDLEWARE_LOGGER = "docpipe.api.middleware.api_logging_middleware"
+
+
+@pytest.fixture(autouse=True)
+def _capture_middleware_logs(caplog):
+    """Attach caplog handler directly — docpipe logger has propagate=False."""
+    middleware_logger = logging.getLogger(_MIDDLEWARE_LOGGER)
+    middleware_logger.addHandler(caplog.handler)
+    middleware_logger.setLevel(logging.DEBUG)
+    yield
+    middleware_logger.removeHandler(caplog.handler)
+
+
+@pytest.fixture
+def mock_request():
+    """Create a mock request for a non-health-check endpoint."""
+    request = MagicMock()
+    request.url.path = "/api/v1/flows"
+    request.method = "GET"
+    return request
+
+
+@pytest.fixture
+def mock_call_next():
+    """Create a mock call_next that returns a 200 response."""
+
+    async def call_next(request):
+        return Response(content="ok", status_code=200)
+
+    return call_next
+
+
+class TestApiLoggingMiddlewareRequestLogging:
+    """Tests for request and response logging behaviour."""
+
+    @pytest.mark.anyio
+    async def test_request_is_logged(self, mock_request, mock_call_next, caplog):
+        """Incoming request method and path should be logged."""
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(mock_request, mock_call_next)
+
+        assert any("Request: GET /api/v1/flows" in msg for msg in caplog.messages)
+
+    @pytest.mark.anyio
+    async def test_response_is_logged_with_status_and_duration(self, mock_request, mock_call_next, caplog):
+        """Response log should include status code, method, path, and duration."""
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(mock_request, mock_call_next)
+
+        response_logs = [msg for msg in caplog.messages if msg.startswith("Response:")]
+        assert len(response_logs) == 1
+        log_line = response_logs[0]
+        assert "200" in log_line
+        assert "GET" in log_line
+        assert "/api/v1/flows" in log_line
+        assert "Duration:" in log_line
+        assert "ms" in log_line
+
+    @pytest.mark.anyio
+    async def test_duration_is_non_negative(self, mock_request, mock_call_next, caplog):
+        """Duration reported in the log must be >= 0."""
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(mock_request, mock_call_next)
+
+        response_logs = [msg for msg in caplog.messages if msg.startswith("Response:")]
+        # Extract duration value from "Duration: 0.12ms"
+        log_line = response_logs[0]
+        duration_str = log_line.split("Duration: ")[1].rstrip("]").replace("ms", "")
+        assert float(duration_str) >= 0
+
+
+class TestApiLoggingMiddlewareHealthCheckFiltering:
+    """Tests for health check endpoint filtering."""
+
+    @pytest.mark.anyio
+    async def test_health_path_is_not_logged(self, mock_call_next, caplog):
+        """Requests to /health should not produce any log output."""
+        request = MagicMock()
+        request.url.path = "/health"
+        request.method = "GET"
+
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(request, mock_call_next)
+
+        assert len(caplog.messages) == 0
+
+    @pytest.mark.anyio
+    async def test_root_path_is_not_logged(self, mock_call_next, caplog):
+        """Requests to / should not produce any log output."""
+        request = MagicMock()
+        request.url.path = "/"
+        request.method = "GET"
+
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(request, mock_call_next)
+
+        assert len(caplog.messages) == 0
+
+    @pytest.mark.anyio
+    async def test_non_health_endpoint_is_logged(self, mock_call_next, caplog):
+        """Non-health endpoints should be logged normally."""
+        request = MagicMock()
+        request.url.path = "/api/v1/operators"
+        request.method = "POST"
+
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        await middleware.dispatch(request, mock_call_next)
+
+        assert any("Request: POST /api/v1/operators" in msg for msg in caplog.messages)
+
+
+class TestApiLoggingMiddlewareResponsePreservation:
+    """Tests that the middleware does not alter the response."""
+
+    @pytest.mark.anyio
+    async def test_response_status_code_preserved(self, mock_request):
+        """Middleware must not alter the response status code."""
+
+        async def call_next(request):
+            return Response(content="created", status_code=201)
+
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        assert response.status_code == 201
+
+    @pytest.mark.anyio
+    async def test_response_body_preserved(self, mock_request, mock_call_next):
+        """Middleware must not alter the response body."""
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(mock_request, mock_call_next)
+
+        assert response.body == b"ok"
+
+    @pytest.mark.anyio
+    async def test_health_check_response_passed_through(self):
+        """Health check response must be returned unmodified."""
+        request = MagicMock()
+        request.url.path = "/health"
+        request.method = "GET"
+
+        async def call_next(request):
+            return Response(content="healthy", status_code=200)
+
+        middleware = ApiLoggingMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 200
+        assert response.body == b"healthy"

--- a/tests/unit/api/middleware/test_security_headers.py
+++ b/tests/unit/api/middleware/test_security_headers.py
@@ -1,0 +1,190 @@
+"""Unit tests for SecurityHeadersMiddleware."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.responses import Response
+
+from docpipe.api.middleware.security_headers import (
+    API_CSP,
+    DOCS_CSP,
+    SecurityHeadersMiddleware,
+)
+
+
+@pytest.fixture
+def mock_call_next():
+    """Create a mock call_next that returns a 200 response."""
+
+    async def call_next(request):
+        return Response(content="ok", status_code=200)
+
+    return call_next
+
+
+def _make_request(*, path: str) -> MagicMock:
+    """Create a mock request with the given URL path."""
+    request = MagicMock()
+    request.url.path = path
+    request.method = "GET"
+    return request
+
+
+class TestSecurityHeadersMiddlewareCommonHeaders:
+    """Tests for security headers applied to all responses."""
+
+    @pytest.mark.anyio
+    async def test_x_content_type_options_header(self, mock_call_next):
+        """X-Content-Type-Options should be set to nosniff."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    @pytest.mark.anyio
+    async def test_x_frame_options_header(self, mock_call_next):
+        """X-Frame-Options should be set to DENY."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert response.headers["X-Frame-Options"] == "DENY"
+
+    @pytest.mark.anyio
+    async def test_referrer_policy_header(self, mock_call_next):
+        """Referrer-Policy should be set to no-referrer."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert response.headers["Referrer-Policy"] == "no-referrer"
+
+    @pytest.mark.anyio
+    async def test_content_security_policy_header_present(self, mock_call_next):
+        """Content-Security-Policy header should always be present."""
+        request = _make_request(path="/api/v1/operators")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert "Content-Security-Policy" in response.headers
+
+
+class TestSecurityHeadersMiddlewareCSPPolicy:
+    """Tests for differentiated CSP policies (strict API vs relaxed docs)."""
+
+    @pytest.mark.anyio
+    async def test_strict_csp_for_api_endpoint(self, mock_call_next):
+        """API endpoints should receive the strict CSP without unsafe directives."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == API_CSP
+        assert "unsafe-inline" not in csp
+        assert "unsafe-eval" not in csp
+
+    @pytest.mark.anyio
+    async def test_relaxed_csp_for_docs_path(self, mock_call_next):
+        """The /api/v1/docs path should receive relaxed CSP for Swagger UI."""
+        request = _make_request(path="/api/v1/docs")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == DOCS_CSP
+        assert "unsafe-inline" in csp
+        assert "unsafe-eval" in csp
+
+    @pytest.mark.anyio
+    async def test_relaxed_csp_for_redoc_path(self, mock_call_next):
+        """The /api/v1/redoc path should receive relaxed CSP for ReDoc."""
+        request = _make_request(path="/api/v1/redoc")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == DOCS_CSP
+
+    @pytest.mark.anyio
+    async def test_strict_csp_for_non_docs_path(self, mock_call_next):
+        """Non-docs paths should receive the strict API CSP."""
+        request = _make_request(path="/api/v1/job-runs")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == API_CSP
+
+    @pytest.mark.anyio
+    async def test_strict_csp_for_root_path(self, mock_call_next):
+        """The root path should receive the strict API CSP."""
+        request = _make_request(path="/")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == API_CSP
+
+    @pytest.mark.anyio
+    async def test_docs_subpath_gets_relaxed_csp(self, mock_call_next):
+        """Subpaths under /api/v1/docs should also get relaxed CSP."""
+        request = _make_request(path="/api/v1/docs/oauth2-redirect")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        csp = response.headers["Content-Security-Policy"]
+        assert csp == DOCS_CSP
+
+
+class TestSecurityHeadersMiddlewareResponsePreservation:
+    """Tests that the middleware does not alter the original response."""
+
+    @pytest.mark.anyio
+    async def test_response_status_code_preserved(self, mock_call_next):
+        """Middleware must not alter the response status code."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_response_body_preserved(self, mock_call_next):
+        """Middleware must not alter the response body."""
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, mock_call_next)
+
+        assert response.body == b"ok"
+
+    @pytest.mark.anyio
+    async def test_error_response_gets_security_headers(self):
+        """Security headers should be added even to error responses."""
+
+        async def error_call_next(request):
+            return Response(content="error", status_code=500)
+
+        request = _make_request(path="/api/v1/flows")
+        middleware = SecurityHeadersMiddleware(app=MagicMock())
+
+        response = await middleware.dispatch(request, error_call_next)
+
+        assert response.status_code == 500
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["Referrer-Policy"] == "no-referrer"
+        assert "Content-Security-Policy" in response.headers


### PR DESCRIPTION
**Issue**
Closes #41

**Description**
Added comprehensive unit tests for two previously untested API middleware components:
- `ApiLoggingMiddleware`: coverage for request/response logging, health check filtering, duration calculations, and response preservation.
- `SecurityHeadersMiddleware`: coverage for common security headers (X-Frame-Options, etc.), strict vs relaxed CSP policies based on path, and error response handling.

**Basic Checklist**
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality
- [x] Documentation updated (N/A)
- [x] No breaking changes

**Testing Details**
- 9 tests added for `ApiLoggingMiddleware`
- 13 tests added for `SecurityHeadersMiddleware`
All 78 middleware tests pass with zero regressions. Pre-commit hooks ran and passed locally.

**Pre-Commit Hook Results**
```text
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
mixed line ending........................................................Passed
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
mypy.....................................................................Passed
Detect secrets...........................................................Passed
