### PR TITLE
fix(ci): remove redundant install step from pypi workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,12 +21,6 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Install system dependencies
-        run: sudo apt-get install -y libldap2-dev libsasl2-dev
-
-      - name: Install dependencies
-        run: uv pip install --system -e .
-
       - name: Build package
         run: uv build --out-dir dist/
 


### PR DESCRIPTION
## Issue
- No linked issue

## Dev Tracking
N/A

## Description
The `pypi.yml` release workflow was failing with a PEP 668 error:

```
error: The interpreter at /usr is externally managed
hint: Virtual environments were not considered due to the `--system` flag
```

`astral-sh/setup-uv@v7` with `python-version` set only sets `UV_PYTHON` — it does not create a venv. Using `--system` forced uv to target the externally-managed Ubuntu system Python, which is blocked under PEP 668.

The install step (`uv pip install --system -e .`) was also redundant — `uv build` invokes the build backend (hatchling) directly and does not require the package or its dependencies to be installed first. The system dependencies step (`libldap2-dev`, `libsasl2-dev`) was similarly unnecessary at build time.

Both steps have been removed. The build job is now: checkout → install uv → `uv build` → upload artifact.

## Basic Checklist
- [ ] Code follows project standards (keyword-only arguments, no unicode in logging)
- [ ] Tests added/updated for new functionality
- [x] Documentation updated (see Documentation Update Checklist below)
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
None

## Testing Details
Verified by inspecting the `uv build` command — it invokes the hatchling build backend directly from `pyproject.toml` without requiring an active environment.

## Documentation Update Checklist
- [x] N/A - No documentation updates needed

### Pre-Commit Hook Results
```
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
Detect secrets...........................................................Passed
```