### PR TITLE
fix(assets): replace datetime.utcnow() and naive datetime.min with timezone-aware UTC equivalents

### DIFF
--- a/src/docpipe/core/assets/document_libraries/adapters/duckdb/metadata_repository.py
+++ b/src/docpipe/core/assets/document_libraries/adapters/duckdb/metadata_repository.py
@@ -6,7 +6,7 @@ This adapter implements the repository port using a hybrid approach:
 """
 
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from docpipe.core.assets.document_libraries.domain.models.document_library import DocumentLibrary
@@ -260,7 +260,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             if deleted:
                 with self._connection_manager.get_connection(database_path=self._database_path) as conn:
                     conn.execute(
-                        f"DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE} WHERE library_id = ?",
+                        f"DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE} WHERE library_id = ?",  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
                         (library_id,),
                     )
 
@@ -396,8 +396,8 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                     INSERT INTO {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                     (library_id, document_set_id, added_at)
                     VALUES (?, ?, ?)
-                    """,
-                    (library_id, document_set_id, datetime.utcnow()),
+                    """,  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
+                    (library_id, document_set_id, datetime.now(UTC)),
                 )
 
             logger.info(f"Added document set {document_set_id} to library {library_id}")
@@ -452,7 +452,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                     f"""
                     DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                     WHERE library_id = ? AND document_set_id = ?
-                    """,
+                    """,  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
                     (library_id, document_set_id),
                 )
 
@@ -495,7 +495,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                     FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                     WHERE library_id = ?
                     ORDER BY added_at
-                    """,
+                    """,  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
                     (library_id,),
                 ).fetchall()
 
@@ -553,10 +553,10 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 INSERT INTO {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 (library_id, document_set_id, added_at)
                 VALUES {placeholders}
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             # Flatten params: (lib_id, doc_set_id, timestamp) for each document set
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(UTC)
             params = []
             for doc_set_id in document_set_ids:
                 params.extend([library_id, doc_set_id, timestamp])
@@ -622,7 +622,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 WHERE library_id = ? AND document_set_id IN ({placeholders})
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             params = (library_id, *document_set_ids)
 
@@ -679,7 +679,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
 
             # Test junction table connectivity
             with self._connection_manager.get_connection(database_path=self._database_path) as conn:
-                conn.execute(f"SELECT COUNT(*) FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}").fetchone()
+                conn.execute(f"SELECT COUNT(*) FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}").fetchone()  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             return HealthCheckResult(
                 healthy=True,

--- a/src/docpipe/core/assets/document_libraries/adapters/repositories/duckdb_document_library_metadata_repository.py
+++ b/src/docpipe/core/assets/document_libraries/adapters/repositories/duckdb_document_library_metadata_repository.py
@@ -5,7 +5,7 @@ This adapter implements the repository port using DuckDB storage.
 
 import json
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 
 from docpipe.core.assets.document_libraries.adapters.storage.duckdb_storage import DuckDBStorage
 from docpipe.core.assets.document_libraries.domain.models.document_library import DocumentLibrary
@@ -64,7 +64,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 INSERT INTO {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 (library_id, name, description, purpose, original_size, final_size, tags, created_by, href)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             # Serialize tags to JSON string if present
             tags_json = json.dumps(library.tags) if library.tags else None
@@ -113,7 +113,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 SELECT library_id, name, description, purpose, original_size, final_size, tags, created_by, href
                 FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 WHERE library_id = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             row = self.storage.fetch_one(query=query, params=(library_id,))
 
@@ -149,7 +149,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 SELECT library_id, name, description, purpose, original_size, final_size, tags, created_by, href
                 FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 WHERE name = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             row = self.storage.fetch_one(query=query, params=(name,))
 
@@ -203,7 +203,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                     created_by = ?,
                     href = ?
                 WHERE library_id = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             # Serialize tags to JSON string if present
             tags_json = json.dumps(library.tags) if library.tags else None
@@ -256,7 +256,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 DELETE FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 WHERE library_id = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             self.storage.execute_query(query=query, params=(library_id,))
 
@@ -293,7 +293,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 SELECT library_id, name, description, purpose, original_size, final_size, tags, created_by, href
                 FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 ORDER BY name ASC
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             if limit is not None:
                 query += f" LIMIT {limit}"
@@ -334,7 +334,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 SELECT COUNT(*) FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 WHERE library_id = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             row = self.storage.fetch_one(query=query, params=(library_id,))
             return row[0] > 0 if row else False
@@ -362,7 +362,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 SELECT COUNT(*) FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
                 WHERE name = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             row = self.storage.fetch_one(query=query, params=(name,))
             return row[0] > 0 if row else False
@@ -404,11 +404,11 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 INSERT INTO {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 (library_id, document_set_id, added_at)
                 VALUES (?, ?, ?)
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             self.storage.execute_query(
                 query=query,
-                params=(library_id, document_set_id, datetime.utcnow()),
+                params=(library_id, document_set_id, datetime.now(UTC)),
             )
 
             logger.info(msg=f"Added document set {document_set_id} to library {library_id}")
@@ -461,7 +461,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 WHERE library_id = ? AND document_set_id = ?
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             self.storage.execute_query(
                 query=query,
@@ -510,7 +510,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 WHERE library_id = ?
                 ORDER BY added_at
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             rows = self.storage.fetch_all(query=query, params=(library_id,))
             return [row[0] for row in rows]
@@ -570,10 +570,10 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
                 INSERT INTO {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 (library_id, document_set_id, added_at)
                 VALUES {placeholders}
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             # Flatten params: (lib_id, doc_set_id, timestamp) for each document set
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(UTC)
             params = []
             for doc_set_id in document_set_ids:
                 params.extend([library_id, doc_set_id, timestamp])
@@ -641,7 +641,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
             query = f"""
                 DELETE FROM {DocpipeConstants.LIBRARY_DOCUMENTSET_JUNCTION_TABLE}
                 WHERE library_id = ? AND document_set_id IN ({placeholders})
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             params = (library_id, *document_set_ids)
 
@@ -675,7 +675,7 @@ class DuckDBDocumentLibraryMetadataRepository(DocumentLibraryRepository):
         try:
             query = f"""
                 SELECT COUNT(*) FROM {DocpipeConstants.DOCUMENT_LIBRARY_TABLE_NAME}
-            """
+            """  # nosec B608 — table name is DocpipeConstants internal constant, not user-supplied input
 
             row = self.storage.fetch_one(query=query)
             return row[0] if row else 0

--- a/src/docpipe/core/assets/document_sets/adapters/duckdb/metadata_repository.py
+++ b/src/docpipe/core/assets/document_sets/adapters/duckdb/metadata_repository.py
@@ -5,7 +5,7 @@ interface, handling CRUD operations for document set metadata using KeyValueStor
 """
 
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Iterator
 
 from docpipe.core.assets.document_sets.domain.models.data_card import DataCard
@@ -286,7 +286,7 @@ class DuckDBDocumentSetMetadataRepository(DocumentSetMetadataRepository):
             document_sets = [self._dict_to_document_set(data=record) for record in all_records]
 
             # Sort by created_at descending (handle None values)
-            document_sets.sort(key=lambda ds: ds.created_at or datetime.min, reverse=True)
+            document_sets.sort(key=lambda ds: ds.created_at or datetime.min.replace(tzinfo=UTC), reverse=True)
 
             logger.debug(f"Retrieved {len(document_sets)} document sets")
             return document_sets

--- a/tests/unit/core/assets/document_libraries/adapters/duckdb/__init__.py
+++ b/tests/unit/core/assets/document_libraries/adapters/duckdb/__init__.py
@@ -1,0 +1,1 @@
+"""DuckDB adapter tests for document libraries."""

--- a/tests/unit/core/assets/document_libraries/adapters/duckdb/test_duckdb_document_library_metadata_repository.py
+++ b/tests/unit/core/assets/document_libraries/adapters/duckdb/test_duckdb_document_library_metadata_repository.py
@@ -1,0 +1,125 @@
+"""Unit tests for DuckDBDocumentLibraryMetadataRepository (adapters/duckdb/).
+
+Verifies that add_document_set_to_library and add_document_sets_bulk pass
+timezone-aware UTC timestamps into the junction table — covering the
+datetime.now(UTC) fix at metadata_repository.py:400 and :559.
+
+This class uses:
+  __init__(self, *, key_value_storage: KeyValueStorage, database_path: str)
+  Junction-table SQL: self._connection_manager.get_connection(...) -> conn.execute(query, params)
+  Existence check:   self.storage.record_exists(...)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import docpipe.core.assets.document_libraries.adapters.duckdb.metadata_repository as repo_module
+from docpipe.core.assets.document_libraries.adapters.duckdb.metadata_repository import (
+    DuckDBDocumentLibraryMetadataRepository,
+)
+
+
+def _make_repo(mock_conn: MagicMock) -> DuckDBDocumentLibraryMetadataRepository:
+    """Instantiate DuckDBDocumentLibraryMetadataRepository with all I/O mocked.
+
+    DuckDBConnectionManager is patched at module level so _initialize_junction_table()
+    runs without a real DB. mock_conn is reset afterwards so tests start clean.
+    """
+    key_value_storage = MagicMock()
+    key_value_storage.record_exists.return_value = True  # exists() passes
+
+    mock_connection_manager = MagicMock()
+    mock_connection_manager.get_connection.return_value.__enter__.return_value = mock_conn
+
+    with patch.object(repo_module, "DuckDBConnectionManager", return_value=mock_connection_manager):
+        repo = DuckDBDocumentLibraryMetadataRepository(
+            key_value_storage=key_value_storage,
+            database_path="data/test.duckdb",
+        )
+
+    # _initialize_junction_table() called conn.execute() 3x (CREATE TABLE + 2 indexes)
+    # reset so individual tests see only their own calls.
+    mock_conn.reset_mock()
+    return repo
+
+
+class TestAddDocumentSetTimestamp:
+    """Verify add_document_set_to_library and add_document_sets_bulk pass
+    timezone-aware UTC timestamps into the junction table.
+
+    Targets adapters/duckdb/metadata_repository.py which routes junction-table
+    SQL through _connection_manager.get_connection() -> conn.execute(query, params).
+    """
+
+    @pytest.fixture
+    def mock_conn(self) -> MagicMock:
+        """Mock DuckDB connection yielded by the connection manager's context manager."""
+        conn = MagicMock()
+        conn.execute.return_value = None
+        return conn
+
+    @pytest.fixture
+    def lib_repo(self, mock_conn: MagicMock) -> DuckDBDocumentLibraryMetadataRepository:
+        return _make_repo(mock_conn)
+
+    def test_add_document_set_passes_timezone_aware_timestamp(
+        self, lib_repo: DuckDBDocumentLibraryMetadataRepository, mock_conn: MagicMock
+    ) -> None:
+        """add_document_set_to_library must insert a timezone-aware UTC timestamp."""
+        lib_repo.add_document_set_to_library(library_id="lib-1", document_set_id="ds-1")
+
+        mock_conn.execute.assert_called_once()
+        # conn.execute(query, (library_id, document_set_id, timestamp))
+        params = mock_conn.execute.call_args.args[1]
+        timestamp = params[2]
+
+        assert timestamp.tzinfo is not None, "added_at must be timezone-aware"
+        assert timestamp.utcoffset().total_seconds() == 0
+
+    def test_bulk_add_document_sets_passes_timezone_aware_timestamp(
+        self, lib_repo: DuckDBDocumentLibraryMetadataRepository, mock_conn: MagicMock
+    ) -> None:
+        """add_document_sets_bulk must insert timezone-aware UTC timestamps for all rows."""
+        lib_repo.add_document_sets_bulk(library_id="lib-1", document_set_ids=["ds-1", "ds-2"])
+
+        mock_conn.execute.assert_called_once()
+        # Flat params tuple: (lib_id, ds_id, timestamp) * n_sets
+        params = mock_conn.execute.call_args.args[1]
+
+        # Timestamps are at indices 2, 5, ...
+        timestamps = [params[i] for i in range(2, len(params), 3)]
+        assert len(timestamps) == 2
+        for ts in timestamps:
+            assert ts.tzinfo is not None, "added_at must be timezone-aware"
+            assert ts.utcoffset().total_seconds() == 0
+
+    def test_bulk_add_empty_list_is_noop(
+        self, lib_repo: DuckDBDocumentLibraryMetadataRepository, mock_conn: MagicMock
+    ) -> None:
+        """Bulk add with an empty list must not call conn.execute."""
+        lib_repo.add_document_sets_bulk(library_id="lib-1", document_set_ids=[])
+
+        mock_conn.execute.assert_not_called()
+
+    def test_add_document_set_raises_when_library_not_found(
+        self, lib_repo: DuckDBDocumentLibraryMetadataRepository, mock_conn: MagicMock
+    ) -> None:
+        """add_document_set_to_library must raise DocpipeException(404) when library is absent."""
+        from docpipe.exceptions.docpipe_exceptions import DocpipeException
+
+        lib_repo.storage.record_exists.return_value = False  # exists() → False
+        with pytest.raises(DocpipeException, match="not found"):
+            lib_repo.add_document_set_to_library(library_id="bad-id", document_set_id="ds-1")
+        mock_conn.execute.assert_not_called()
+
+    def test_bulk_add_raises_when_library_not_found(
+        self, lib_repo: DuckDBDocumentLibraryMetadataRepository, mock_conn: MagicMock
+    ) -> None:
+        """add_document_sets_bulk must raise DocpipeException(404) when library is absent."""
+        from docpipe.exceptions.docpipe_exceptions import DocpipeException
+
+        lib_repo.storage.record_exists.return_value = False  # exists() → False
+        with pytest.raises(DocpipeException, match="not found"):
+            lib_repo.add_document_sets_bulk(library_id="bad-id", document_set_ids=["ds-1"])
+        mock_conn.execute.assert_not_called()

--- a/tests/unit/core/operators/document_sets/test_duckdb_adapters.py
+++ b/tests/unit/core/operators/document_sets/test_duckdb_adapters.py
@@ -1,5 +1,9 @@
 """Unit tests for DuckDB adapters implementing hexagonal architecture ports."""
 
+import types
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
 import pyarrow as pa
 import pytest
 
@@ -116,6 +120,69 @@ class TestDuckDBMetadataRepository:
             "Test Set 1",
             "Test Set 2",
         }
+
+    def test_list_all_sorted_newest_first(self, *, metadata_repository):
+        """list_all returns records ordered by created_at descending."""
+
+        def _record(asset_id, name, created_at):
+            return {
+                "asset_id": asset_id,
+                "name": name,
+                "description": None,
+                "storage_backend": "duckdb",
+                "total_documents": 0,
+                "total_size_bytes": 0,
+                "total_pages": 0,
+                "created_at": created_at,
+                "updated_at": "2024-01-01T00:00:00+00:00",
+                "metadata": {},
+                "data_card": None,
+            }
+
+        records = [
+            _record("sort-1", "Oldest", "2024-01-01T00:00:00+00:00"),
+            _record("sort-2", "Newest", "2024-06-01T00:00:00+00:00"),
+            _record("sort-3", "Middle", "2024-03-01T00:00:00+00:00"),
+        ]
+        with patch.object(metadata_repository._storage, "list_records", return_value=records):
+            result = metadata_repository.list_all()
+
+        assert [r.name for r in result] == ["Newest", "Middle", "Oldest"]
+
+    def test_list_all_none_created_at_does_not_raise(self, *, metadata_repository):
+        """list_all must not raise TypeError when a record has created_at=None."""
+        records: list[dict[str, object]] = [
+            {
+                "asset_id": "none-1",
+                "name": "With Date",
+                "description": None,
+                "storage_backend": "duckdb",
+                "total_documents": 0,
+                "total_size_bytes": 0,
+                "total_pages": 0,
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "updated_at": "2024-01-01T00:00:00+00:00",
+                "metadata": {},
+                "data_card": None,
+            },
+            {
+                "asset_id": "none-2",
+                "name": "No Date",
+                "description": None,
+                "storage_backend": "duckdb",
+                "total_documents": 0,
+                "total_size_bytes": 0,
+                "total_pages": 0,
+                "created_at": None,
+                "updated_at": None,
+                "metadata": {},
+                "data_card": None,
+            },
+        ]
+        with patch.object(metadata_repository._storage, "list_records", return_value=records):
+            result = metadata_repository.list_all()
+
+        assert len(result) == 2
 
     def test_update_document_set(self, *, metadata_repository):
         """Test updating document set metadata."""
@@ -384,3 +451,57 @@ class TestSanitizeTableName:
     def test_sanitize_table_name(self, name: str, expected: str) -> None:
         """Test table name sanitization produces correct output."""
         assert sanitize_table_name(name) == expected
+
+
+class TestDuckDBDocumentSetMetadataRepositorySorting:
+    """Regression tests for the datetime.min -> datetime.min.replace(tzinfo=UTC) fix
+    in DuckDBDocumentSetMetadataRepository.list_all() (DTZ001).
+
+    Targets adapters/duckdb/metadata_repository.py directly, not the generic
+    DuckDBAssetRepository, since that is the class whose sort line was changed.
+
+    _dict_to_document_set uses a legacy DocumentSet constructor signature that no
+    longer matches the current model, so it is patched to return controlled objects.
+    The tests focus purely on the sort logic at metadata_repository.py:289.
+    """
+
+    @pytest.fixture
+    def mock_storage(self) -> MagicMock:
+        storage = MagicMock()
+        storage.collection_exists.return_value = True
+        return storage
+
+    @pytest.fixture
+    def ds_repo(self, mock_storage: MagicMock):
+        from docpipe.core.assets.document_sets.adapters.duckdb.metadata_repository import (
+            DuckDBDocumentSetMetadataRepository,
+        )
+
+        return DuckDBDocumentSetMetadataRepository(key_value_storage=mock_storage, database_path="data/test.duckdb")
+
+    def test_list_all_sorted_newest_first(self, ds_repo, mock_storage: MagicMock) -> None:
+        """list_all must return records sorted by created_at descending."""
+        ds_oldest = types.SimpleNamespace(name="Oldest", created_at=datetime(2024, 1, 1, tzinfo=UTC))
+        ds_newest = types.SimpleNamespace(name="Newest", created_at=datetime(2024, 6, 1, tzinfo=UTC))
+        ds_middle = types.SimpleNamespace(name="Middle", created_at=datetime(2024, 3, 1, tzinfo=UTC))
+
+        mock_storage.list_records.return_value = [{}, {}, {}]
+        with patch.object(ds_repo, "_dict_to_document_set", side_effect=[ds_oldest, ds_newest, ds_middle]):
+            result = ds_repo.list_all()
+
+        assert [ds.name for ds in result] == ["Newest", "Middle", "Oldest"]
+
+    def test_list_all_none_created_at_does_not_raise(self, ds_repo, mock_storage: MagicMock) -> None:
+        """A record with created_at=None must not raise TypeError — the
+        datetime.min.replace(tzinfo=UTC) sentinel allows comparison against
+        timezone-aware datetimes without error."""
+        ds_with = types.SimpleNamespace(name="With Date", created_at=datetime(2024, 1, 1, tzinfo=UTC))
+        ds_none = types.SimpleNamespace(name="No Date", created_at=None)
+
+        mock_storage.list_records.return_value = [{}, {}]
+        with patch.object(ds_repo, "_dict_to_document_set", side_effect=[ds_with, ds_none]):
+            result = ds_repo.list_all()
+
+        assert len(result) == 2
+        assert result[0].name == "With Date"
+        assert result[1].name == "No Date"


### PR DESCRIPTION


- Replace datetime.utcnow() with datetime.now(UTC) in DuckDB document library repositories
- Use timezone-aware datetime.min.replace(tzinfo=UTC) for document set list sorting
- Update unit tests to verify UTC-aware persistence and None-safe sorting

Closes #20

<!--
Note -
1. Ensure that an appropriate title is given to the PR in the Title bar of the PR
2. Headings that are not applicable to the PR can be removed from the below template
-->

## Issue
- https://github.com/IBM/docling-pipelines/issues/20

## Dev Tracking
<!-- Link to epic or parent task if this PR is part of a larger feature/epic -->
<!-- Example: Part of Epic #123 or Subtask of #456 -->

## Description
Replaces timezone-naive datetime usages (`datetime.utcnow()` and naive `datetime.min`) with timezone-aware UTC equivalents across the asset repository layer to resolve Ruff DTZ (flake8-datetimez) violations (DTZ001, DTZ003) and avoid subtle comparison errors when sorting assets with mixed or null timestamps.

Key changes:
- Replaced `datetime.utcnow()` with `datetime.now(UTC)` in `DuckDBDocumentLibraryMetadataRepository` and `duckdb/metadata_repository.py` for junction table insertions.
- Replaced naive `datetime.min` fallback with `datetime.min.replace(tzinfo=UTC)` in `DuckDBDocumentSetMetadataRepository.list_all()`, matching the established pattern in `DuckDBAssetRepository`.
- Added `from datetime import UTC` imports where missing.
- Added tests/unit/core/assets/document_libraries/adapters/duckdb/test_duckdb_document_library_metadata_repository.py (new file) and updated tests/unit/core/operators/document_sets/test_duckdb_adapters.py to verify UTC-aware junction table timestamps and null-safe descending sort ordering.
- Note: modifying these files caused bandit's pre-commit hook to re-scan them in full, surfacing ~15 pre-existing B608 (hardcoded-SQL) warnings unrelated to this fix. Added # nosec B608 with justification comments (table names come from internal DocpipeConstants, not user input) so pre-commit passes.

## Basic Checklist
- [x] Code follows project standards (keyword-only arguments, no unicode in logging)
- [x] Tests added/updated for new functionality
- [x] Documentation updated - N/A (see Documentation Update Checklist below) 
- [x] No breaking changes (or documented in Breaking Changes section)

## Breaking Changes
None

## Dependencies
None

## Testing Details
- **Unit Tests Added/Updated**:
  - `tests/unit/core/operators/document_sets/test_duckdb_adapters.py`: Added `TestDuckDBDocumentSetMetadataRepositorySorting` (test_list_all_sorted_newest_first, test_list_all_none_created_at_does_not_raise), targeting `DuckDBDocumentSetMetadataRepository.list_all()` directly to verify the `datetime.min.replace(tzinfo=UTC)` fix.
  - `tests/unit/core/assets/document_libraries/adapters/duckdb/test_duckdb_document_library_metadata_repository.py (new file)`: Added `TestAddDocumentSetTimestamp `covering single and bulk document set additions on the live `DuckDBDocumentLibraryMetadataRepository (adapters/duckdb/)`, verifying added_at is timezone-aware UTC. Note: the duplicate implementation at adapters/repositories/duckdb_document_library_metadata_repository.py was also fixed for consistency but is currently unreferenced by the factory/production code, so it has no dedicated test.
- **Commands Executed**:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest tests/unit/core/assets/ tests/unit/core/operators/document_sets/ -v`

## Documentation Update Checklist
<!-- Check all documentation files that were updated or reviewed for this PR -->
- [ ] README.md (if adding features, changing structure, or modifying setup)
- [ ] ARCHITECTURE.md (if modifying operators, data flow, or system design)
- [ ] CONTRIBUTING.md (if changing development workflow or code standards)
- [ ] USER_GUIDE_PIPELINE_SETUP.md (if changing installation, setup, or execution)
- [ ] QUICKSTART.md (if changing quick start steps or examples)
- [ ] docs/reference/OPERATORS.md (if adding/modifying operators)
- [ ] TROUBLESHOOTING.md (if discovering new issues or solutions)
- [ ] Operator documentation in docs/operators/ (if operator added/modified)
- [ ] N/A - No documentation updates needed


### Pre-Commit Hook Results
```
git commit
uv-export............................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
mixed line ending........................................................Passed
nbstripout...........................................(no files to check)Skipped
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
bandit...................................................................Passed
mypy.....................................................................Passed
interrogate..............................................................Passed
Detect secrets...........................................................Passed
```


### Note
 1. **Keyword Arguments** - Ensure function arguments are keyword-based, not positional - [Link](https://docs.python.org/3/glossary.html#term-argument)
 2. **Metadata Independence:** When adding or modifying operator metadata, ensure the data does not depend on instance variables.
 3. **Method Requirements:** Ensure `get_metadata` is a static method. If `get_required_features` depends on instance variables, the operator must implement `get_static_required_features` using the default values referenced in `get_required_features`
 4. For every PR, ensure that the pre-commit hook output has been included.